### PR TITLE
slog-extlog panics when you write a log with stats annotations though…

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -241,10 +241,11 @@ where
     fn update_stats(&self, log: &StatTrigger) {
         for defn in log.stat_list() {
             if log.condition(*defn) {
-                let stat = &self.stats.get(defn.name()).expect(
+                let stat = &self.stats.get(defn.name()).expect(&format!(
                     "No statistic found with name {}, did you try writing a log through
                     a logger which wasn't initialized with your stats definitions?",
-                );
+                    defn.name()
+                ));
                 stat.value
                     .update(&log.change(*defn).expect("Bad log definition"));
                 // If this is a grouped stat, then we may also need to update the grouped

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -241,7 +241,10 @@ where
     fn update_stats(&self, log: &StatTrigger) {
         for defn in log.stat_list() {
             if log.condition(*defn) {
-                let stat = &self.stats[defn.name()];
+                let stat = &self.stats.get(defn.name()).expect(
+                    "No statistic found with name {}, did you try writing a log through
+                    a logger which wasn't initialized with your stats definitions?",
+                );
                 stat.value
                     .update(&log.change(*defn).expect("Bad log definition"));
                 // If this is a grouped stat, then we may also need to update the grouped


### PR DESCRIPTION
… a logger which wasn't initialized with the corresponding stats struct

This fix doesn't change that, but at least tries to point you in the right direction when it happens.

Signed-off-by: Nigel Thorpe <nigel.thorpe@metaswitch.com>