### PR TITLE
Stats config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 
+## [4.0.0]
+### Changed
+ - Some small but breaking changes to stats creation API.
+   - No longer require an instance of the formatter type.
+   - Take a list of `StatsDefinitions` so users can track stats from multiple crates in one place.
+
 ### Fixed
 - Proper `Clone` support for `StatisticsLogger`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "3.2.0"
+version = "4.0.0"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
 homepage = "https://github.com/Metaswitch/slog-extlog"
@@ -42,7 +42,7 @@ bencher = "0.1.5"
 # This is a known problem in Cargo - see
 # https://github.com/rust-lang/cargo/issues/4242 for tracking issue.
 [dev-dependencies.slog-extlog-derive]
-version = "3.2"
+version = "4.0"
 path = "slog-extlog-derive"
 
 [workspace]

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -80,8 +80,8 @@ fn setup_logger() -> StatisticsLogger<DefaultStatisticsLogFormatter> {
     let core = Core::new().expect("Failed to initialize tokio core");
     StatisticsLogger::new(
         slog::Logger::root(slog::Discard, o!()),
-        StatsConfigBuilder::new(DefaultStatisticsLogFormatter)
-            .with_stats(SLOG_TEST_STATS)
+        StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
+            .with_stats(vec![SLOG_TEST_STATS])
             .with_core(core.handle())
             .fuse(), // LCOV_EXCL_LINE Kcov bug?
     )
@@ -127,7 +127,12 @@ fn single_grouped_counter_multi_bucket(bench: &mut Bencher) {
     let logger = setup_logger();
     let mut idx = 0;
     bench.iter(|| {
-        xlog!(logger, ThirdExternalLog { name: format!("name-{}", idx) });
+        xlog!(
+            logger,
+            ThirdExternalLog {
+                name: format!("name-{}", idx),
+            }
+        );
         idx += 1;
     })
 }
@@ -162,7 +167,9 @@ fn get_stats(bench: &mut Bencher) {
         }
     );
 
-    bench.iter(|| { logger.get_stats(); })
+    bench.iter(|| {
+        logger.get_stats();
+    })
 }
 
 benchmark_group!(

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 slog =  { version = "2.1", features = ['nested-values'] }
 syn = {version = "0.11.9", features = ["full"] }
 quote = "0.3.10"
-slog-extlog = { version = "3.2", path = ".." }
+slog-extlog = { version = "4.0", path = ".." }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-extlog-derive"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -140,7 +140,8 @@
 //! }
 //!
 //! fn main() {
-//!   let cfg = stats::StatsConfig {stats:  FOO_STATS, ..Default::default() };
+//!   let cfg = stats::StatsConfigBuilder::<stats::DefaultStatisticsLogFormatter>::new().
+//!       with_stats(vec![FOO_STATS]).fuse();
 //!
 //!   // Create the logger using whatever log format required.
 //!   let slog_logger = slog::Logger::root(slog::Discard, o!());

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -18,7 +18,7 @@ extern crate erased_serde;
 
 use slog::Logger;
 use std::str;
-use slog_extlog::stats::StatisticsLogger;
+use slog_extlog::stats::{DefaultStatisticsLogFormatter, StatisticsLogger};
 use slog_extlog::slog_test;
 
 const CRATE_LOG_NAME: &str = "SLOGTST";
@@ -41,7 +41,7 @@ fn test_basic_log() {
     struct BasicLog;
 
     let (logger, mut data) = create_logger("basic_log");
-    let logger = StatisticsLogger::new(logger, Default::default());
+    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
     xlog!(logger, BasicLog);
     let logs = slog_test::read_json_values(&mut data);
     assert_eq!(logs.len(), 1);
@@ -72,13 +72,14 @@ fn test_derived_structs() {
     // LCOV_EXCL_STOP
 
     let (logger, mut data) = create_logger("derived_structs");
-    let logger = StatisticsLogger::new(logger, Default::default());
+    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
     let foo_logger = logger.new(o!("data" => FooData {
         id: 10,
         user: "Bob".to_string(),
         count: 2,
     }));
-    let foo_logger = StatisticsLogger::new(foo_logger, Default::default());
+    let foo_logger =
+        StatisticsLogger::<DefaultStatisticsLogFormatter>::new(foo_logger, Default::default());
 
     xlog!(foo_logger, FooRspRcvd(FooRspType::Ok, "Success"));
     let logs = slog_test::read_json_values(&mut data);
@@ -124,7 +125,7 @@ fn test_fixed_field() {
     };
 
     let (logger, mut data) = create_logger("fixed_field");
-    let logger = StatisticsLogger::new(logger, Default::default());
+    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
     xlog!(logger, my_log);
 
     let logs = slog_test::read_json_values(&mut data);
@@ -168,7 +169,7 @@ fn test_generics() {
     // LCOV_EXCL_STOP
 
     let (logger, mut data) = create_logger("derived_structs");
-    let logger = StatisticsLogger::new(logger, Default::default());
+    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
     let foo_data = FooData {
         id: 42,
         desc: "FoobarBaz",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //!     let logger = slog::Logger::root(
 //!         Mutex::new(slog_json::Json::default(std::io::stdout())).map(slog::Fuse),
 //!         o!());
-//!     let foo_logger = stats::StatisticsLogger::new(
+//!     let foo_logger = stats::StatisticsLogger::<stats::DefaultStatisticsLogFormatter>::new(
 //!                        logger.new(o!("cxt" =>
 //!                          FooContext {
 //!                            id: "123456789".to_string(),
@@ -153,6 +153,7 @@
 //! [`xlog!()`]: macro.xlog.html
 
 // Copyright 2017 Metaswitch Networks
+
 extern crate serde;
 #[macro_use]
 extern crate slog;

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -155,7 +155,7 @@ pub fn create_logger_buffer(
 
     let logger = StatisticsLogger::new(
         logger,
-        StatsConfigBuilder::new(DefaultStatisticsLogFormatter)
+        StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
             .with_log_interval(TEST_LOG_INTERVAL)
             .with_stats(stats)
             .fuse(), // LCOV_EXCL_LINE Kcov bug?
@@ -225,14 +225,15 @@ pub fn check_expected_stat_snaphots(
         assert_eq!(found_stat.definition.description(), stat.description);
 
         for value in stat.values.iter() {
-            let found_value = found_stat.values.iter().find(|val| {
-                val.group_values == value.group_values
-            });
+            let found_value = found_stat
+                .values
+                .iter()
+                .find(|val| val.group_values == value.group_values);
             assert!(
                 found_value.is_some(),
                 "Failed to find value with groups {:?} for stat {}",
                 value.group_values, // LCOV_EXCL_LINE
-                stat.name // LCOV_EXCL_LINE
+                stat.name           // LCOV_EXCL_LINE
             );
             let found_value = found_value.unwrap();
             assert_eq!(found_value.group_values, found_value.group_values);

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -157,7 +157,7 @@ pub fn create_logger_buffer(
         logger,
         StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
             .with_log_interval(TEST_LOG_INTERVAL)
-            .with_stats(stats)
+            .with_stats(vec![stats])
             .fuse(), // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
     (logger, data)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -8,7 +8,7 @@
 //! of logging.
 //!
 //! Users should use the [`define_stats`] macro to list their statistics.  They can then pass the
-//! list (along with stats from any sepenedncies) to a [`StatisticsLogger`] wrapping an
+//! list (along with stats from any dependencies) to a [`StatisticsLogger`] wrapping an
 //! [`slog:Logger`].  The statistics trigger function on the `ExtLoggable` objects then triggers
 //! statistic updates based on logged values.
 //!

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -247,11 +247,13 @@ where
     fn update_stats(&self, log: &StatTrigger) {
         for defn in log.stat_list() {
             if log.condition(*defn) {
-                let stat = &self.stats.get(defn.name()).expect(&format!(
-                    "No statistic found with name {}, did you try writing a log through
-                    a logger which wasn't initialized with your stats definitions?",
-                    defn.name()
-                ));
+                let stat = &self.stats.get(defn.name()).unwrap_or_else(|| {
+                    panic!(
+                        "No statistic found with name {}, did you try writing a log through a
+                         logger which wasn't initialized with your stats definitions?",
+                        defn.name()
+                    )
+                });
                 stat.value
                     .update(&log.change(*defn).expect("Bad log definition"));
                 // If this is a grouped stat, then we may also need to update the grouped

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,12 +7,15 @@
 //! statistic.   This generates fast, compile-time checking for statistics updates at the point
 //! of logging.
 //!
-//! Users should use the [`define_stats`] macro to list their statistics, and then pass the
-//! list to a [`StatisticsLogger`] wrapping an [`slog:Logger`].  They can then use the statistics
-//! trigger function on the `ExtLoggable` objects to triggwr statistic updates based on logged
-//! values.
+//! Users should use the [`define_stats`] macro to list their statistics.  They can then pass the
+//! list (along with stats from any sepenedncies) to a [`StatisticsLogger`] wrapping an
+//! [`slog:Logger`].  The statistics trigger function on the `ExtLoggable` objects then triggers
+//! statistic updates based on logged values.
 //!
-//! Triggers should be added to `ExtLoggable` objects using the [`slog-extlog-derive`] crate.
+//! Library users should export the result of `define_stats!`, so that binary developers can
+//! track the set of stats from all dependent crates in a single tracker.
+//!
+//! Triggers should be added to [`ExtLoggable`] objects using the [`slog-extlog-derive`] crate.
 //!
 //! [`ExtLoggable`]: ../slog-extlog/trait.ExtLoggable.html
 //! [`define_stats`]: ./macro.define_stats.html


### PR DESCRIPTION
This makes small changes to the stats creation API for some better flexibility in usage.
- No need to provide an instance of the formatter on `StatisticsLogger::new()`, just a type annotation.
- `StatisticsLogger` is now correctly cloneable.
- Can pass multiple stats definition sets into a single logger.

Breaking change, so bumping major version and getting this in now before the stats tracking is widely used.

