### PR TITLE
Prepare move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 
+## [4.1.0]
+### Added
+- Add a `DefaultLogger` for users who don't need statistics.
+- Move repository homepage.
+
 ## [4.0.0]
 ### Changed
  - Some small but breaking changes to stats creation API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "4.0.0"
+version = "4.1.0"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
-homepage = "https://github.com/Metaswitch/slog-extlog"
-repository = "https://github.com/Metaswitch/slog-extlog"
+homepage = "https://github.com/slog-rs/extlog"
+repository = "https://github.com/slog-rs/extlog"
 keywords = ["slog", "log", "logging"]
 readme = "README.md"
 
@@ -42,7 +42,7 @@ bencher = "0.1.5"
 # This is a known problem in Cargo - see
 # https://github.com/rust-lang/cargo/issues/4242 for tracking issue.
 [dev-dependencies.slog-extlog-derive]
-version = "4.0"
+version = "4.1"
 path = "slog-extlog-derive"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 
-This repository adds support for **external logs**, and for statistics tracking through those logs, to the [`slog`](https://github.com/slog-rs/slog/) ecosystem.
+This crate adds support for **external logs**, and for statistics tracking through those logs, to the [`slog`](https://github.com/slog-rs/slog/) ecosystem.
+
+This crate was written by Metaswitch Networks (@Metaswitch) and made freely available under the [Apache License](LICENSE.md).
+[Contributions](CONTRIBUTING.md) are welcome.
 
 # Overview
 
-**External logs** are logs that form an external API that end users can rely on, and that do not change without explicit agreement.
+**External logs** are logs that form an external API that end users can rely on, and that do not change without explicit agreement. Using them allows
+you to treat logs as objects, rather than strings with metadata, allowing compile-time checking of logs.
 
 This repository provides the following.
  - An API for easily defining external logs.

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "slog-extlog-derive"
-version = "4.0.0"
+version = "4.1.0"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"
-homepage = "https://github.com/Metaswitch/slog-extlog"
-repository = "https://github.com/Metaswitch/slog-extlog"
+homepage = "https://github.com/slog-rs/extlog"
+repository = "https://github.com/slog-rs/extlog"
 keywords = ["slog", "log", "logging"]
 readme = "../README.md"
 
@@ -13,7 +13,7 @@ readme = "../README.md"
 slog =  { version = "2.1", features = ['nested-values'] }
 syn = {version = "0.11.9", features = ["full"] }
 quote = "0.3.10"
-slog-extlog = { version = "4.0", path = ".." }
+slog-extlog = { version = "4.1", path = ".." }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -17,9 +17,9 @@ extern crate slog_extlog_derive;
 extern crate erased_serde;
 
 use slog::Logger;
-use std::str;
-use slog_extlog::stats::{DefaultStatisticsLogFormatter, StatisticsLogger};
+use slog_extlog::DefaultLogger;
 use slog_extlog::slog_test;
+use std::str;
 
 const CRATE_LOG_NAME: &str = "SLOGTST";
 
@@ -41,7 +41,7 @@ fn test_basic_log() {
     struct BasicLog;
 
     let (logger, mut data) = create_logger("basic_log");
-    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
+    let logger = DefaultLogger::new(logger, Default::default());
     xlog!(logger, BasicLog);
     let logs = slog_test::read_json_values(&mut data);
     assert_eq!(logs.len(), 1);
@@ -72,14 +72,13 @@ fn test_derived_structs() {
     // LCOV_EXCL_STOP
 
     let (logger, mut data) = create_logger("derived_structs");
-    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
+    let logger = DefaultLogger::new(logger, Default::default());
     let foo_logger = logger.new(o!("data" => FooData {
         id: 10,
         user: "Bob".to_string(),
         count: 2,
     }));
-    let foo_logger =
-        StatisticsLogger::<DefaultStatisticsLogFormatter>::new(foo_logger, Default::default());
+    let foo_logger = DefaultLogger::new(foo_logger, Default::default());
 
     xlog!(foo_logger, FooRspRcvd(FooRspType::Ok, "Success"));
     let logs = slog_test::read_json_values(&mut data);
@@ -125,7 +124,7 @@ fn test_fixed_field() {
     };
 
     let (logger, mut data) = create_logger("fixed_field");
-    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
+    let logger = DefaultLogger::new(logger, Default::default());
     xlog!(logger, my_log);
 
     let logs = slog_test::read_json_values(&mut data);
@@ -169,7 +168,7 @@ fn test_generics() {
     // LCOV_EXCL_STOP
 
     let (logger, mut data) = create_logger("derived_structs");
-    let logger = StatisticsLogger::<DefaultStatisticsLogFormatter>::new(logger, Default::default());
+    let logger = DefaultLogger::new(logger, Default::default());
     let foo_data = FooData {
         id: 42,
         desc: "FoobarBaz",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,15 @@
 //!     `ExtLoggable` trait for this object.
 //!      - If your structure is overly complex or unusual, manually implement [`ExtLoggable`].
 //!   - Early in your program or libary, obtain or create a [`Logger`] of the correct format and
-//!   wrap it in a ['StatisticsLogger`].
+//!     wrap it in a ['StatisticsLogger`].
 //!
-//!   You can then call the [`xlog!()`] macro, passing in a [`StatisticsLogger`] and an instance of
-//!   your structure, and it will be logged according to the Logger's associated Drain as usual.
-//!   Structure parameters  will be added as key-value pairs, but with the bonus that you get
-//!   type checking.
+//! Unless you want to support statistics tracking, then the easiest way to obtain an
+//! appropriate logger is to create a [`DefaultLogger`](./type.DefaultLogger.html).
+//!
+//! You can then call the [`xlog!()`] macro, passing in the [`StatisticsLogger`] and an instance
+//! of your structure, and it will be logged according to the Logger's associated Drain as usual.
+//! Structure parameters will be added as key-value pairs, but with the bonus that you get
+//! type checking.
 //!
 //! You can continue to make developer logs simply using `slog` as normal:
 //!
@@ -86,7 +89,7 @@
 //! extern crate serde_derive;
 //! extern crate erased_serde;
 //!
-//! use slog_extlog::{ExtLoggable, stats};
+//! use slog_extlog::{DefaultLogger, ExtLoggable};
 //! use slog::Drain;
 //! use std::sync::Mutex;
 //!
@@ -126,7 +129,7 @@
 //!     let logger = slog::Logger::root(
 //!         Mutex::new(slog_json::Json::default(std::io::stdout())).map(slog::Fuse),
 //!         o!());
-//!     let foo_logger = stats::StatisticsLogger::<stats::DefaultStatisticsLogFormatter>::new(
+//!     let foo_logger = DefaultLogger::new(
 //!                        logger.new(o!("cxt" =>
 //!                          FooContext {
 //!                            id: "123456789".to_string(),
@@ -170,15 +173,16 @@ pub mod slog_test;
 /// A trait that defines requirements to be automatically derivable.
 ///
 /// Any generic parameters in `ExtLoggable` objects must have this as a trait bound.
-pub trait SlogValueDerivable
-    : std::fmt::Debug + Clone + serde::Serialize + Send + 'static {
-}
+pub trait SlogValueDerivable: std::fmt::Debug + Clone + serde::Serialize + Send + 'static {}
 
 impl<T> SlogValueDerivable for T
 where
     T: std::fmt::Debug + Clone + serde::Serialize + Send + 'static,
 {
 }
+
+/// The default logger type.
+pub type DefaultLogger = stats::StatisticsLogger<stats::DefaultStatisticsLogFormatter>;
 
 /// An object that can be logged.
 ///


### PR DESCRIPTION
Prepare to transfer ownership into the slog ecosystem.  Also a small enhancement to add a `DefaultLogger` type so that you can avoid all mention of stats if you don't want to use them.