### PR TITLE
Bucket Counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 ### Added
+
+## [5.0.0]
+### Changed
+### Added
 - Add the `BucketCounter` stat type for tracking stats grouped into numerical ranges.
 
 ## [4.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+### Added
+- Add the `BucketCounter` stat type for tracking stats grouped into numerical ranges.
 
 ## [4.1.0]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "4.1.0"
+version = "5.0.0"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
 homepage = "https://github.com/slog-rs/extlog"
@@ -42,7 +42,7 @@ bencher = "0.1.5"
 # This is a known problem in Cargo - see
 # https://github.com/rust-lang/cargo/issues/4242 for tracking issue.
 [dev-dependencies.slog-extlog-derive]
-version = "4.1"
+version = "5"
 path = "slog-extlog-derive"
 
 [workspace]

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-extlog-derive"
-version = "4.1.0"
+version = "5.0.0"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"
@@ -13,7 +13,7 @@ readme = "../README.md"
 slog =  { version = "2.1", features = ['nested-values'] }
 syn = {version = "0.11.9", features = ["full"] }
 quote = "0.3.10"
-slog-extlog = { version = "4.1", path = ".." }
+slog-extlog = { version = "5", path = ".." }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -391,13 +391,8 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         let id = &t.id.to_string();
         let bucket = t.bucket_by.clone();
         if let Some(bucket) = bucket {
-            // let bucket_str = bucket.to_string();
             stats_buckets = quote! { #stats_buckets
                 #id => Some(self.#bucket as f64),
-            }
-        } else {
-            stats_buckets = quote! { #stats_buckets
-                #id => None,
             }
         }
     }
@@ -734,10 +729,9 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
             .map(|f| f.clone().ident.expect("No identifier for field!"))
             .collect::<Vec<_>>();
 
-        assert!(
-            bucket_by_fields.len() <= 1,
-            "The BucketBy attribute can be added to at most one field"
-        );
+        if bucket_by_fields.len() > 1 {
+            panic!("The BucketBy attribute can be added to at most one field");
+        }
 
         bucket_by_fields.into_iter().next()
     } else {

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -113,6 +113,7 @@
 //!
 //! use slog_extlog::{ExtLoggable, stats};
 //! use slog_extlog::stats::StatDefinition;
+//! use slog_extlog::stats::Buckets;
 //!
 //! // The prefix to add to all log identifiers.
 //! const CRATE_LOG_NAME: &'static str = "FOO";
@@ -209,7 +210,6 @@ struct StatTriggerData {
     val: StatTriggerValue,
     group_by: Vec<syn::Ident>,
     bucket_by: Option<syn::Ident>,
-    // bucket_data: Option<BucketData>,
 }
 
 /// Generate implementations of the `slog::Value` trait.
@@ -401,22 +401,6 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
             }
         }
     }
-
-    // let mut buckets = quote!{};
-    // for t in &triggers {
-    //     let id = &t.id.to_string();
-    //     let bucket_data = t.bucket_data.clone();
-    //     let bucket_field_str = bucket_data.bucket_field_id.to_string();
-    //     buckets = quote! { #buckets
-    //         #id => {
-    //             if let Some(bucket_data) = bucket_data {
-
-    //             } else {
-    //                 None
-    //             }
-    //         },
-    //     }
-    // }
 
     // Tweak to ensure we avoid unused variable warnings in `get_tag_value()`.
     let tag_name_ident = if !triggers.is_empty() {

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -322,7 +322,7 @@ fn get_types_bounds(
 }
 
 fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
-    // Get stat triggering details.roups.
+    // Get stat triggering details.
     let triggers = ast.attrs
         .iter()
         .filter(|a| a.name() == "StatTrigger")
@@ -744,22 +744,6 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
         None
     };
 
-    // let bucket_data = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
-    //     let bucket_field = fields.iter().find(|f| {
-    //         f.attrs
-    //             .iter()
-    //             .any(|a| a.name() == "BucketBy" && is_attr_stat_id(a, &id))
-    //     });
-
-    //     if let Some(bucket_field) = bucket_field {
-    //         Some(parse_buckets(bucket_field, &id))
-    //     } else {
-    //         None
-    //     }
-    // } else {
-    //     None
-    // };
-
     StatTriggerData {
         id,
         // If no condition is provided, default to always passing.  Unwrap is OK here as we are
@@ -772,37 +756,3 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
     }
 }
 // LCOV_EXCL_STOP
-//
-
-// struct BucketData {
-//     bucket_field_id: syn::Ident,
-//     bucket_limits: Vec<f64>,
-// }
-
-// fn parse_buckets(field: &syn::Field, id: &syn::Ident) -> BucketData {
-//     let attr = field
-//         .attrs
-//         .iter()
-//         .find(|a| a.name() == "BucketBy" && is_attr_stat_id(a, id))
-//         .expect("didn't find BucketBy attribute");
-
-//     let bucket_limits = if let syn::MetaItem::List(_, ref items) = attr.value {
-//         items
-//             .iter()
-//             .map(|item| {
-//                 if let syn::NestedMetaItem::Literal(syn::Lit::Float(s, _)) = item {
-//                     s.parse::<f64>().expect("Could not parse a bucket value")
-//                 } else {
-//                     panic!("Could not parse a bucket value");
-//                 }
-//             })
-//             .collect()
-//     } else {
-//         panic!("Could not parse a bucket value");
-//     };
-
-//     BucketData {
-//         bucket_field_id: field.ident.clone().expect("No ident"),
-//         bucket_limits,
-//     }
-// }

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -391,9 +391,9 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         let id = &t.id.to_string();
         let bucket = t.bucket_by.clone();
         if let Some(bucket) = bucket {
-            let bucket_str = bucket.to_string();
+            // let bucket_str = bucket.to_string();
             stats_buckets = quote! { #stats_buckets
-                #id => Some(self.#bucket_str),
+                #id => Some(self.#bucket as f64),
             }
         } else {
             stats_buckets = quote! { #stats_buckets

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -208,6 +208,7 @@ struct StatTriggerData {
     action: StatTriggerAction,
     val: StatTriggerValue,
     group_by: Vec<syn::Ident>,
+    // bucket_data: Option<BucketData>,
 }
 
 /// Generate implementations of the `slog::Value` trait.
@@ -380,6 +381,22 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
             },
         }
     }
+
+    // let mut buckets = quote!{};
+    // for t in &triggers {
+    //     let id = &t.id.to_string();
+    //     let bucket_data = t.bucket_data.clone();
+    //     let bucket_field_str = bucket_data.bucket_field_id.to_string();
+    //     buckets = quote! { #buckets
+    //         #id => {
+    //             if let Some(bucket_data) = bucket_data {
+
+    //             } else {
+    //                 None
+    //             }
+    //         },
+    //     }
+    // }
 
     // Tweak to ensure we avoid unused variable warnings in `get_tag_value()`.
     let tag_name_ident = if !triggers.is_empty() {
@@ -693,21 +710,21 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
         vec![]
     };
 
-    let bucket_data = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
-        let bucket_field = fields.iter().find(|f| {
-            f.attrs
-                .iter()
-                .any(|a| a.name() == "BucketBy" && is_attr_stat_id(a, &id))
-        });
+    // let bucket_data = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
+    //     let bucket_field = fields.iter().find(|f| {
+    //         f.attrs
+    //             .iter()
+    //             .any(|a| a.name() == "BucketBy" && is_attr_stat_id(a, &id))
+    //     });
 
-        if let Some(bucket_field) = bucket_field {
-            Some(parse_buckets(bucket_field, &id))
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    //     if let Some(bucket_field) = bucket_field {
+    //         Some(parse_buckets(bucket_field, &id))
+    //     } else {
+    //         None
+    //     }
+    // } else {
+    //     None
+    // };
 
     StatTriggerData {
         id,
@@ -717,40 +734,41 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
         action: action.expect("StatTrigger missing value for Action"),
         val: value.expect("StatTrigger missing value for Value or ValueFrom"),
         group_by: groups,
+        // bucket_data,
     }
 }
 // LCOV_EXCL_STOP
 //
 
-struct BucketData {
-    bucket_field_id: syn::Ident,
-    bucket_limits: Vec<f64>,
-}
+// struct BucketData {
+//     bucket_field_id: syn::Ident,
+//     bucket_limits: Vec<f64>,
+// }
 
-fn parse_buckets(field: &syn::Field, id: &syn::Ident) -> BucketData {
-    let attr = field
-        .attrs
-        .iter()
-        .find(|a| a.name() == "BucketBy" && is_attr_stat_id(a, id))
-        .expect("didn't find BucketBy attribute");
+// fn parse_buckets(field: &syn::Field, id: &syn::Ident) -> BucketData {
+//     let attr = field
+//         .attrs
+//         .iter()
+//         .find(|a| a.name() == "BucketBy" && is_attr_stat_id(a, id))
+//         .expect("didn't find BucketBy attribute");
 
-    let bucket_limits = if let syn::MetaItem::List(_, ref items) = attr.value {
-        items
-            .iter()
-            .map(|item| {
-                if let syn::NestedMetaItem::Literal(syn::Lit::Float(s, _)) = item {
-                    s.parse::<f64>().expect("Could not parse a bucket value")
-                } else {
-                    panic!("Could not parse a bucket value");
-                }
-            })
-            .collect()
-    } else {
-        panic!("Could not parse a bucket value");
-    };
+//     let bucket_limits = if let syn::MetaItem::List(_, ref items) = attr.value {
+//         items
+//             .iter()
+//             .map(|item| {
+//                 if let syn::NestedMetaItem::Literal(syn::Lit::Float(s, _)) = item {
+//                     s.parse::<f64>().expect("Could not parse a bucket value")
+//                 } else {
+//                     panic!("Could not parse a bucket value");
+//                 }
+//             })
+//             .collect()
+//     } else {
+//         panic!("Could not parse a bucket value");
+//     };
 
-    BucketData {
-        bucket_field_id: field.ident.clone().expect("No ident"),
-        bucket_limits,
-    }
-}
+//     BucketData {
+//         bucket_field_id: field.ident.clone().expect("No ident"),
+//         bucket_limits,
+//     }
+// }

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -17,8 +17,8 @@ extern crate slog_extlog_derive;
 extern crate erased_serde;
 
 use slog::Logger;
-use slog_extlog::DefaultLogger;
 use slog_extlog::slog_test;
+use slog_extlog::DefaultLogger;
 use std::str;
 
 const CRATE_LOG_NAME: &str = "SLOGTST";

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -202,6 +202,7 @@ pub struct ExpectedStatSnapshot {
     pub description: &'static str,
     pub stat_type: StatType,
     pub values: Vec<ExpectedStatSnapshotValue>,
+    pub buckets: Option<Buckets>,
 }
 
 #[derive(Debug)]
@@ -225,12 +226,11 @@ pub fn check_expected_stat_snaphots(
 
         assert_eq!(found_stat.definition.stype(), stat.stat_type);
         assert_eq!(found_stat.definition.description(), stat.description);
+        assert_eq!(found_stat.definition.buckets(), stat.buckets);
 
         match found_stat.values {
             StatSnapshotValues::Counter(ref vals) | StatSnapshotValues::Gauge(ref vals) => {
-                // panic!();
-                //
-                for value in stat.values.iter() {
+                for value in &stat.values {
                     let found_value = vals.iter()
                         .find(|val| val.group_values == value.group_values);
 
@@ -248,7 +248,8 @@ pub fn check_expected_stat_snaphots(
             }
 
             StatSnapshotValues::BucketCounter(ref buckets, ref vals) => {
-                for value in stat.values.iter() {
+                assert_eq!(Some(buckets), stat.buckets.as_ref());
+                for value in &stat.values {
                     let found_value = vals.iter().find(|(val, bucket)| {
                         val.group_values == value.group_values
                             && Some(bucket) == value.bucket_limit.as_ref()

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -223,6 +223,9 @@ pub fn check_expected_stat_snaphots(
         assert!(found_stat.is_some(), "Failed to find stat {}", stat.name);
         let found_stat = found_stat.unwrap();
 
+        println!("expected stat: {:?}", stat);
+        println!("found stat: {:?}", found_stat);
+
         assert_eq!(found_stat.definition.stype(), stat.stat_type);
         assert_eq!(found_stat.definition.description(), stat.description);
 

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -223,10 +223,6 @@ pub fn check_expected_stat_snaphots(
         assert!(found_stat.is_some(), "Failed to find stat {}", stat.name);
         let found_stat = found_stat.unwrap();
 
-        println!("expected stat: {:?}", stat);
-        println!("found stat: {:?}", found_stat);
-        println!("found stat type: {:?}", found_stat.definition.stype());
-
         assert_eq!(found_stat.definition.stype(), stat.stat_type);
         assert_eq!(found_stat.definition.description(), stat.description);
 

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -59,10 +59,10 @@ pub extern crate slog_json;
 pub use super::stats::*;
 
 use super::slog;
-use std::sync::Mutex;
 use std::io;
 #[allow(unused_imports)] // we need this trait for lines()
 use std::io::BufRead;
+use std::sync::Mutex;
 
 /// Create a new test logger suitable for use with `read_json_values`.
 pub fn new_test_logger<T: io::Write + Send + 'static>(stream: T) -> slog::Logger {

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -169,16 +169,6 @@ pub struct ExpectedStat {
     pub tag: Option<&'static str>,
     pub value: f64,
     pub metric_type: &'static str,
-    pub bucket: Option<BucketLimit>,
-}
-
-impl BucketLimit {
-    fn equals(&self, value: &serde_json::Value) -> bool {
-        match self {
-            BucketLimit::Num(f) => value.as_f64() == Some(*f),
-            BucketLimit::Unbounded => value == "Unbounded",
-        }
-    }
 }
 
 /// Asserts that a set of logs (retrieved using `logs_in_range)` is exactly equal to an
@@ -191,7 +181,6 @@ pub fn check_expected_stats(logs: &[serde_json::Value], mut expected_stats: Vec<
         for (id, exp) in expected_stats.iter().enumerate() {
             if log["name"] == exp.stat_name
                 && (exp.tag.is_none() || log["tags"] == exp.tag.unwrap())
-                && (exp.bucket.is_none() || exp.bucket.unwrap().equals(&log["bucket"]))
             {
                 assert_eq!(logs[0]["metric_type"], exp.metric_type);
                 assert_eq!(log["value"].as_f64(), Some(exp.value));

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -225,6 +225,7 @@ pub fn check_expected_stat_snaphots(
 
         println!("expected stat: {:?}", stat);
         println!("found stat: {:?}", found_stat);
+        println!("found stat type: {:?}", found_stat.definition.stype());
 
         assert_eq!(found_stat.definition.stype(), stat.stat_type);
         assert_eq!(found_stat.definition.description(), stat.description);

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -208,7 +208,7 @@ pub struct ExpectedStatSnapshot {
 pub struct ExpectedStatSnapshotValue {
     pub group_values: Vec<String>,
     pub value: f64,
-    pub bucket_index: Option<usize>,
+    pub bucket_limit: Option<BucketLimit>,
 }
 // LCOV_EXCL_STOP
 
@@ -226,24 +226,47 @@ pub fn check_expected_stat_snaphots(
         assert_eq!(found_stat.definition.stype(), stat.stat_type);
         assert_eq!(found_stat.definition.description(), stat.description);
 
-        for value in stat.values.iter() {
-            let found_value = found_stat.values.iter().find(|val| {
-                val.group_values == value.group_values && val.bucket_index == value.bucket_index
-            });
-            assert!(
-                found_value.is_some(),
-                "Failed to find value with groups {:?} and bucket_index {:?} for stat {}",
-                value.group_values, // LCOV_EXCL_LINE
-                value.bucket_index, // LCOV_EXCL_LINE
-                stat.name           // LCOV_EXCL_LINE
-            );
-            let found_value = found_value.unwrap();
-            assert_eq!(found_value.group_values, found_value.group_values);
-            assert_eq!(found_value.value, value.value);
-            assert_eq!(found_value.bucket_index, value.bucket_index);
-        }
+        match found_stat.values {
+            StatSnapshotValues::Counter(ref vals) | StatSnapshotValues::Gauge(ref vals) => {
+                // panic!();
+                //
+                for value in stat.values.iter() {
+                    let found_value = vals.iter()
+                        .find(|val| val.group_values == value.group_values);
 
-        assert_eq!(found_stat.values.len(), stat.values.len());
+                    assert!(
+                        found_value.is_some(),
+                        "Failed to find value with groups {:?} and bucket_limit {:?} for stat {}",
+                        value.group_values, // LCOV_EXCL_LINE
+                        value.bucket_limit, // LCOV_EXCL_LINE
+                        stat.name           // LCOV_EXCL_LINE
+                    );
+                    let found_value = found_value.unwrap();
+                    assert_eq!(found_value.group_values, value.group_values);
+                    assert_eq!(found_value.value, value.value);
+                }
+            }
+
+            StatSnapshotValues::BucketCounter(ref buckets, ref vals) => {
+                for value in stat.values.iter() {
+                    let found_value = vals.iter().find(|(val, bucket)| {
+                        val.group_values == value.group_values
+                            && Some(bucket) == value.bucket_limit.as_ref()
+                    });
+
+                    assert!(
+                        found_value.is_some(),
+                        "Failed to find value with groups {:?} and bucket_limit {:?} for stat {}",
+                        value.group_values, // LCOV_EXCL_LINE
+                        value.bucket_limit, // LCOV_EXCL_LINE
+                        stat.name           // LCOV_EXCL_LINE
+                    );
+                    let (found_value, _) = found_value.unwrap();
+                    assert_eq!(found_value.group_values, value.group_values);
+                    assert_eq!(found_value.value, value.value);
+                }
+            }
+        }
     }
 
     assert_eq!(stats.len(), expected_stats.len());

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -245,8 +245,8 @@ pub fn check_expected_stat_snaphots(
                 found_value.is_some(),
                 "Failed to find value with groups {:?} and bucket_index {:?} for stat {}",
                 value.group_values, // LCOV_EXCL_LINE
-                value.bucket_index,
-                stat.name // LCOV_EXCL_LINE
+                value.bucket_index, // LCOV_EXCL_LINE
+                stat.name           // LCOV_EXCL_LINE
             );
             let found_value = found_value.unwrap();
             assert_eq!(found_value.group_values, found_value.group_values);

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -243,7 +243,7 @@ pub fn check_expected_stat_snaphots(
             });
             assert!(
                 found_value.is_some(),
-                "Failed to find value with groups {:?} and bucket_inxex {:?} for stat {}",
+                "Failed to find value with groups {:?} and bucket_index {:?} for stat {}",
                 value.group_values, // LCOV_EXCL_LINE
                 value.bucket_index,
                 stat.name // LCOV_EXCL_LINE

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -219,6 +219,7 @@ pub struct ExpectedStatSnapshot {
 pub struct ExpectedStatSnapshotValue {
     pub group_values: Vec<String>,
     pub value: f64,
+    pub bucket_index: Option<usize>,
 }
 // LCOV_EXCL_STOP
 
@@ -227,9 +228,6 @@ pub fn check_expected_stat_snaphots(
     stats: &[StatSnapshot],
     expected_stats: &[ExpectedStatSnapshot],
 ) {
-
-    println!("Expected: {:?}", expected_stats);
-    println!("Found: {:?}", stats);
     for stat in expected_stats {
         let found_stat = stats.iter().find(|s| s.definition.name() == stat.name);
 
@@ -240,19 +238,20 @@ pub fn check_expected_stat_snaphots(
         assert_eq!(found_stat.definition.description(), stat.description);
 
         for value in stat.values.iter() {
-            let found_value = found_stat
-                .values
-                .iter()
-                .find(|val| val.group_values == value.group_values);
+            let found_value = found_stat.values.iter().find(|val| {
+                val.group_values == value.group_values && val.bucket_index == value.bucket_index
+            });
             assert!(
                 found_value.is_some(),
-                "Failed to find value with groups {:?} for stat {}",
+                "Failed to find value with groups {:?} and bucket_inxex {:?} for stat {}",
                 value.group_values, // LCOV_EXCL_LINE
-                stat.name           // LCOV_EXCL_LINE
+                value.bucket_index,
+                stat.name // LCOV_EXCL_LINE
             );
             let found_value = found_value.unwrap();
             assert_eq!(found_value.group_values, found_value.group_values);
             assert_eq!(found_value.value, value.value);
+            assert_eq!(found_value.bucket_index, value.bucket_index);
         }
 
         assert_eq!(found_stat.values.len(), stat.values.len());

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -162,7 +162,9 @@ pub trait StatTrigger {
         None
     }
 
-    // fn buckets(&self, stat_id: &StatDefinition, value: f64) -> Buckets;
+    // fn buckets(&self, stat_id: &StatDefinition, value: f64) -> Option<Buckets> {
+    //     None
+    // }
 }
 
 /// Types of changes made to a statistic.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -781,7 +781,7 @@ pub enum StatSnapshotValues {
 }
 
 impl StatSnapshotValues {
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         match self {
             StatSnapshotValues::Counter(ref vals) | StatSnapshotValues::Gauge(ref vals) => {
                 vals.is_empty()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -179,7 +179,7 @@ macro_rules! define_stats {
             /// An optional list of field names to group the statistic by.
             fn group_by(&self) -> Vec<&'static str> { vec![$($tags),*] }
             /// The numerical buckets and bucketing method used to group the statistic.
-            fn buckets(&self) -> Option<Buckets> {
+            fn buckets(&self) -> Option<$crate::stats::Buckets> {
                 match self.stype() {
                     $crate::stats::StatType::BucketCounter => {
                         Some($crate::stats::Buckets::new($crate::stats::BucketMethod::$bmethod,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -161,6 +161,8 @@ pub trait StatTrigger {
     fn change(&self, _stat_id: &StatDefinition) -> Option<ChangeType> {
         None
     }
+
+    // fn buckets(&self, stat_id: &StatDefinition, value: f64) -> Buckets;
 }
 
 /// Types of changes made to a statistic.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -122,7 +122,7 @@ pub trait StatDefinition: fmt::Debug {
 ///
 ///   - The `BucketMethod` determines how the stat will be sorted into numerical buckets and should
 ///   - be a subtype of that enum.
-///   - The bucket limits should be a list of `u64` values, each representing the upper bound of
+///   - The bucket limits should be a list of `i64` values, each representing the upper bound of
 ///     that bucket.
 ///   - The bucket label should describe what the buckets measure and should be distinct from the tags.
 ///     Each stat log will be labelled with the pair `(bucket_label, bucket_value)` in addition to the tags,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,13 +4,13 @@
 //! calculated and reported based on logged events.  The logged events MUST implement the
 //! [`ExtLoggable`] trait.
 //!
-//! To support this, the [`slog-extlog-derive'] crate can be used to link logs to a specific
+//! To support this, the [`slog-extlog-derive`] crate can be used to link logs to a specific
 //! statistic.   This generates fast, compile-time checking for statistics updates at the point
 //! of logging.
 //!
 //! Users should use the [`define_stats`] macro to list their statistics.  They can then pass the
 //! list (along with stats from any dependencies) to a [`StatisticsLogger`] wrapping an
-//! [`slog:Logger`].  The statistics trigger function on the `ExtLoggable` objects then triggers
+//! [`slog::Logger`].  The statistics trigger function on the `ExtLoggable` objects then triggers
 //! statistic updates based on logged values.
 //!
 //! Library users should export the result of `define_stats!`, so that binary developers can
@@ -18,11 +18,11 @@
 //!
 //! Triggers should be added to [`ExtLoggable`] objects using the [`slog-extlog-derive`] crate.
 //!
-//! [`ExtLoggable`]: ../slog-extlog/trait.ExtLoggable.html
-//! [`define_stats`]: ./macro.define_stats.html
-//! [`Logger`]: ../slog/struct.Logger.html)
-//! [`slog`]: ../slog/index.html
-//! [`slog-extlog-derive`]: ../slog_extlog_derive/index.html
+//! [`ExtLoggable`]: ../trait.ExtLoggable.html
+//! [`define_stats`]: ../macro.define_stats.html
+//! [`slog::Logger`]: ../../slog/struct.Logger.html
+//! [`slog`]: ../../slog/index.html
+//! [`slog-extlog-derive`]: ../../slog_extlog_derive/index.html
 //! [`StatisticsLogger`]: ./struct.StatisticsLogger.html
 
 extern crate futures;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -687,7 +687,7 @@ impl<T: StatisticsLogFormatter> Clone for StatisticsLogger<T> {
         StatisticsLogger {
             logger: self.logger.clone(),
             tracker: self.tracker.clone(),
-        }
+        } // LCOV_EXCL_LINE Kcov bug
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -147,9 +147,9 @@ macro_rules! define_stats {
         )*
     };
 
-    // `BucketCounter`s require a `BucketMethod` and bucket limits
+    // `BucketCounter`s require a `BucketMethod`, bucket label and bucket limits
     (@single $stat:ident, BucketCounter, $desc:expr, [$($tags:tt),*], ($bmethod:ident, $blabel:expr, [$($blimits:expr),*]) ) => {
-        define_stats!{@inner $stat, BucketCounter, $desc, $bmethod, [$($tags),*], [$($blimits),*]}
+        define_stats!{@inner $stat, BucketCounter, $desc, $bmethod, $blabel, [$($tags),*], [$($blimits),*]}
     };
 
     // Non `BucketCounter` stat types

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -67,7 +67,7 @@ pub trait StatDefinition: fmt::Debug {
     /// An optional list of field names to group the statistic by.
     fn group_by(&self) -> Vec<&'static str>;
 
-    fn buckets(&self) -> Buckets;
+    fn buckets(&self) -> &'static Buckets;
 }
 
 /// A macro to define the statistics that can be tracked by the logger.
@@ -168,10 +168,10 @@ macro_rules! define_stats {
 
       // Trait impl for StatDefinition
     (@single $stat:ident, $stype:ident, $desc:expr, $bmethod:ident, [$($tags:tt),*], [$($blimits:tt),*]) => {
-
         // Suppress the warning about cases - this value is never going to be seen
         #[allow(non_upper_case_globals)]
         static $stat : inner_stats::$stat = inner_stats::$stat;
+            // static BUCKETS : $crate::stats::Bucket = $crate::stats::Buckets::new($crate::stats::BucketMethod::$bmethod, vec![$($blimits),*]);
 
         impl $crate::stats::StatDefinition for inner_stats::$stat {
             /// The name of this statistic.
@@ -183,8 +183,9 @@ macro_rules! define_stats {
             /// An optional list of field names to group the statistic by.
             fn group_by(&self) -> Vec<&'static str> { vec![$($tags),*] }
 
-            fn buckets(&self) -> Buckets {
-                $crate::stats::Buckets::new($crate::stats::BucketMethod::$bmethod, vec![$($blimits),*])
+            fn buckets(&self) -> &'static Buckets {
+                // &$stat::BUCKETS
+                panic!();
             }
         }
     };
@@ -210,6 +211,9 @@ pub trait StatTrigger {
     fn tag_value(&self, stat_id: &StatDefinition, _tag_name: &'static str) -> String;
     /// The details of the change to make for this stat, if `condition` returned true.
     fn change(&self, _stat_id: &StatDefinition) -> Option<ChangeType> {
+        None
+    }
+    fn bucket_value(&self, _stat_id: &StatDefinition) -> Option<f64> {
         None
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -263,7 +263,7 @@ impl slog::Value for BucketLimit {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct Buckets {
     /// The method to use to sort values into buckets.
-    method: BucketMethod,
+    pub method: BucketMethod,
     /// The upper bounds of the buckets.
     limits: Vec<BucketLimit>,
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -186,7 +186,7 @@ macro_rules! define_stats {
                     $crate::stats::StatType::BucketCounter => {
                         Some($crate::stats::Buckets::new($crate::stats::BucketMethod::$bmethod,
                             $blabel,
-                            vec![$($blimits as i64),* ],
+                            &vec![$($blimits as i64),* ],
                         ))
                     },
                     _ => None

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -474,7 +474,7 @@ where
                     vec![]
                 };
 
-                // For logging purposes we treat the bucket data as another (tag name tag value) pair.
+                // For logging purposes we treat the bucket data as another (tag name, tag value) pair.
                 if let Some(bucket_label_name) = bucket_label_name {
                     tags.push((bucket_label_name, bucket_str))
                 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -259,6 +259,15 @@ impl slog::Value for BucketLimit {
     } // LCOV_EXCL_LINE Kcov bug?
 }
 
+impl fmt::Display for BucketLimit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BucketLimit::Num(val) => write!(f, "{}", val),
+            BucketLimit::Unbounded => write!(f, "Unbounded"),
+        }
+    }
+}
+
 /// A set of numerical buckets together with a method for sorting values into them.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct Buckets {

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -636,7 +636,6 @@ fn test_extloggable_bucket_counter_grouped() {
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
     let logs = get_stat_logs("test_bucket_counter_grouped", &mut data);
-    println!("logs: {:?}", logs);
     assert_eq!(logs.len(), 6);
 
     check_expected_stats(

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -386,6 +386,7 @@ fn test_extloggable_bucket_counter_freq() {
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
     let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
+    println!("logs: {:?}", logs);
     assert_eq!(logs.len(), 5);
 
     check_expected_stats(

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -667,7 +667,7 @@ fn test_extloggable_bucket_counter_grouped() {
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
     let logs = get_stat_logs("test_bucket_counter_grouped", &mut data);
     println!("logs: {:?}", logs);
-    assert_eq!(logs.len(), 5);
+    assert_eq!(logs.len(), 6);
 
     check_expected_stats(
         &logs,

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -110,7 +110,7 @@ struct SixthExternalLog {
     #[BucketBy(StatName = "test_bucket_counter_grouped")]
     floating: f32,
 }
-//LCOV_EXCL_STOP
+// LCOV_EXCL_STOP
 
 // Shortcut for a standard external log of the first struct with given values.
 fn log_external_stat(
@@ -307,14 +307,12 @@ fn basic_extloggable_grouped_by_string() {
                 tag: Some("name=bar"),
                 value: 4f64,
                 metric_type: "counter",
-                bucket: None,
             },
             ExpectedStat {
                 stat_name: "test_grouped_counter",
                 tag: Some("name=foo"),
                 value: 2f64,
                 metric_type: "counter",
-                bucket: None,
             },
         ],
     );
@@ -343,35 +341,30 @@ fn basic_extloggable_grouped_by_mixed() {
                 tag: Some("name=bar,error=0"),
                 value: 2f64,
                 metric_type: "counter",
-                bucket: None,
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=0"),
                 value: 1f64,
                 metric_type: "counter",
-                bucket: None,
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=bar,error=1"),
                 value: 1f64,
                 metric_type: "counter",
-                bucket: None,
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=2"),
                 value: 1f64,
                 metric_type: "counter",
-                bucket: None,
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=bar,error=2"),
                 value: 1f64,
                 metric_type: "counter",
-                bucket: None,
             },
         ],
     );
@@ -392,38 +385,33 @@ fn test_extloggable_bucket_counter_freq() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=1"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(1 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=2"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(2 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=3"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(3 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=4"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(4 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=Unbounded"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );
@@ -449,38 +437,33 @@ fn test_extloggable_bucket_counter_freq_high_value() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=1"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(1 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=2"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(2 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=3"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(3 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=4"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(4 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_freq",
-                tag: None,
+                tag: Some("bucket=Unbounded"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );
@@ -501,38 +484,33 @@ fn test_extloggable_bucket_counter_cumul_freq() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=1"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(1 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=2"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(2 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=3"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(3 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=4"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(4 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=Unbounded"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );
@@ -553,38 +531,33 @@ fn test_extloggable_bucket_counter_cumul_freq_high_value() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=1"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(1 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=2"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(2 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=3"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(3 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=4"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(4 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_cumul_freq",
-                tag: None,
+                tag: Some("bucket=Unbounded"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );
@@ -620,24 +593,21 @@ fn test_extloggable_buckets_and_repeated_tags() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=name,error=3"),
+                tag: Some("name=name,error=3,bucket=-5"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(-5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=name,error=3"),
+                tag: Some("name=name,error=3,bucket=5"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=name,error=3"),
+                tag: Some("name=name,error=3,bucket=Unbounded"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );
@@ -674,45 +644,39 @@ fn test_extloggable_bucket_counter_grouped() {
         vec![
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=first,error=1"),
+                tag: Some("name=first,error=1,bucket=-5"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(-5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=first,error=1"),
+                tag: Some("name=first,error=1,bucket=5"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=first,error=1"),
+                tag: Some("name=first,error=1,bucket=Unbounded"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=second,error=2"),
+                tag: Some("name=second,error=2,bucket=-5"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(-5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=second,error=2"),
+                tag: Some("name=second,error=2,bucket=5"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(5 as f64)),
             },
             ExpectedStat {
                 stat_name: "test_bucket_counter_grouped",
-                tag: Some("name=second,error=2"),
+                tag: Some("name=second,error=2,bucket=Unbounded"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Unbounded),
             },
         ],
     );

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -10,8 +10,8 @@ extern crate slog_extlog;
 #[macro_use]
 extern crate slog_extlog_derive;
 
-use slog_extlog::stats::*;
 use slog_extlog::slog_test::*;
+use slog_extlog::stats::*;
 use std::{panic, thread, time};
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_TRACKER_TEST";
@@ -35,10 +35,15 @@ define_stats! {
 #[LogDetails(Id = "1", Text = "Amount sent", Level = "Info")]
 #[StatTrigger(StatName = "test_counter", Action = "Incr", Value = "1")]
 #[StatTrigger(StatName = "test_second_counter", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_gauge", Condition = "self.bytes < 200", Action = "Incr",
-              Value = "1")]
-#[StatTrigger(StatName = "test_second_gauge", Condition = "self.bytes > self.unbytes as u32",
-              Action = "Incr", ValueFrom = "self.bytes - (self.unbytes as u32)")]
+#[StatTrigger(
+    StatName = "test_gauge", Condition = "self.bytes < 200", Action = "Incr", Value = "1"
+)]
+#[StatTrigger(
+    StatName = "test_second_gauge",
+    Condition = "self.bytes > self.unbytes as u32",
+    Action = "Incr",
+    ValueFrom = "self.bytes - (self.unbytes as u32)"
+)]
 //LCOV_EXCL_START
 struct ExternalLog {
     bytes: u32,
@@ -47,16 +52,18 @@ struct ExternalLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "2", Text = "Some floating point number", Level = "Error")]
-#[StatTrigger(StatName = "test_gauge", Condition = "self.floating > 1.0", Action = "Decr",
-              Value = "1")]
+#[StatTrigger(
+    StatName = "test_gauge", Condition = "self.floating > 1.0", Action = "Decr", Value = "1"
+)]
 struct SecondExternalLog {
     floating: f32,
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "3", Text = "A string of text", Level = "Warning")]
-#[StatTrigger(StatName = "test_foo_count", Condition = "self.name == \"foo\"", Action = "Incr",
-              Value = "1")]
+#[StatTrigger(
+    StatName = "test_foo_count", Condition = "self.name == \"foo\"", Action = "Incr", Value = "1"
+)]
 #[StatTrigger(StatName = "test_grouped_counter", Action = "Incr", Value = "1")]
 struct ThirdExternalLog {
     #[StatGroup(StatName = "test_grouped_counter")]
@@ -66,8 +73,12 @@ struct ThirdExternalLog {
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "4", Text = "Some more irrelevant text", Level = "Info")]
 #[StatTrigger(StatName = "test_double_grouped", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_latest_foo_error_count", Condition = "self.error != 0",
-              Action = "SetVal", ValueFrom = "self.foo_count")]
+#[StatTrigger(
+    StatName = "test_latest_foo_error_count",
+    Condition = "self.error != 0",
+    Action = "SetVal",
+    ValueFrom = "self.foo_count"
+)]
 struct FourthExternalLog {
     #[StatGroup(StatName = "test_double_grouped")]
     name: String,

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -11,7 +11,7 @@ extern crate slog_extlog;
 extern crate slog_extlog_derive;
 
 use slog_extlog::slog_test::*;
-use slog_extlog::stats::*;
+// use slog_extlog::stats::*;
 use std::{panic, thread, time};
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_TRACKER_TEST";

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -385,7 +385,6 @@ fn test_extloggable_bucket_counter_freq() {
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
     let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
-    println!("logs: {:?}", logs);
     assert_eq!(logs.len(), 5);
 
     check_expected_stats(
@@ -592,50 +591,51 @@ fn test_extloggable_bucket_counter_cumul_freq_high_value() {
 }
 
 #[test]
-fn test_extloggable_buckets_and_tags() {
+fn test_extloggable_buckets_and_repeated_tags() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
-    xlog!(logger, FifthExternalLog { floating: 2.5 });
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "name".to_string(),
+            error: 3,
+            floating: -1f32
+        }
+    );
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "name".to_string(),
+            error: 3,
+            floating: 7f32
+        }
+    );
 
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
-    let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
-    assert_eq!(logs.len(), 5);
+    let logs = get_stat_logs("test_bucket_counter_grouped", &mut data);
+    assert_eq!(logs.len(), 3);
 
     check_expected_stats(
         &logs,
         vec![
             ExpectedStat {
-                stat_name: "test_bucket_counter_freq",
-                tag: None,
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3"),
                 value: 0f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(1 as f64)),
+                bucket: Some(BucketLimit::Num(-5 as f64)),
             },
             ExpectedStat {
-                stat_name: "test_bucket_counter_freq",
-                tag: None,
-                value: 0f64,
-                metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(2 as f64)),
-            },
-            ExpectedStat {
-                stat_name: "test_bucket_counter_freq",
-                tag: None,
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3"),
                 value: 1f64,
                 metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(3 as f64)),
+                bucket: Some(BucketLimit::Num(5 as f64)),
             },
             ExpectedStat {
-                stat_name: "test_bucket_counter_freq",
-                tag: None,
-                value: 0f64,
-                metric_type: "bucket counter",
-                bucket: Some(BucketLimit::Num(4 as f64)),
-            },
-            ExpectedStat {
-                stat_name: "test_bucket_counter_freq",
-                tag: None,
-                value: 0f64,
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3"),
+                value: 1f64,
                 metric_type: "bucket counter",
                 bucket: Some(BucketLimit::Unbounded),
             },

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -27,9 +27,9 @@ define_stats! {
         test_double_grouped(Counter, "Test counter grouped by type and error",
                                ["name", "error"]),
         test_latest_foo_error_count(Counter, "Latest foo error byte count", []),
-        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, [1,2,3,4])),
-        test_bucket_counter_cumul_freq(BucketCounter, "Test cumulative bucket counter", [], (CumulFreq, [1,2,3,4])),
-        test_bucket_counter_grouped(BucketCounter, "Test bucket counter grouped by name and error", ["name", "error"], (Freq, [-5, 5]))
+        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, "bucket", [1,2,3,4])),
+        test_bucket_counter_cumul_freq(BucketCounter, "Test cumulative bucket counter", [], (CumulFreq, "bucket", [1,2,3,4])),
+        test_bucket_counter_grouped(BucketCounter, "Test bucket counter grouped by name and error", ["name", "error"], (Freq, "bucket", [-5, 5]))
     }
 }
 

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -11,7 +11,6 @@ extern crate slog_extlog;
 extern crate slog_extlog_derive;
 
 use slog_extlog::slog_test::*;
-// use slog_extlog::stats::*;
 use std::{panic, thread, time};
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_TRACKER_TEST";

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -416,7 +416,11 @@ fn request_for_bucket_counter_freq_one_value() {
 
     assert_eq!(
         stats[0].definition.buckets(),
-        Some(Buckets::new(BucketMethod::Freq, vec![1f64, 2f64, 3f64]))
+        Some(Buckets::new(
+            BucketMethod::Freq,
+            "bucket",
+            vec![1f64, 2f64, 3f64]
+        ))
     );
 
     check_expected_stat_snaphots(
@@ -459,7 +463,11 @@ fn request_for_bucket_counter_cumul_freq() {
 
     assert_eq!(
         stats[0].definition.buckets(),
-        Some(Buckets::new(BucketMethod::CumulFreq, vec![1.5, 2.5, 3.5]))
+        Some(Buckets::new(
+            BucketMethod::CumulFreq,
+            "bucket",
+            vec![1.5, 2.5, 3.5]
+        ))
     );
 
     check_expected_stat_snaphots(
@@ -522,7 +530,11 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
 
     assert_eq!(
         stats[0].definition.buckets(),
-        Some(Buckets::new(BucketMethod::CumulFreq, vec![-1.5f64, 0f64]))
+        Some(Buckets::new(
+            BucketMethod::CumulFreq,
+            "bucket",
+            vec![-1.5f64, 0f64]
+        ))
     );
 
     check_expected_stat_snaphots(

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -24,18 +24,18 @@ define_stats! {
         test_gauge(Gauge, "Test gauge", []),
         test_grouped_counter(Counter, "Test grouped counter", ["counter_group_one", "counter_group_two"]),
         test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"]),
-        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, [1, 2, 3])),
+        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, "bucket", [1, 2, 3])),
         test_bucket_counter_cumul_freq(
             BucketCounter,
             "Test cumulative bucket counter",
             [],
-            (CumulFreq, [1.5, 2.5, 3.5])
+            (CumulFreq, "bucket", [1.5, 2.5, 3.5])
         ),
         test_group_bucket_counter(
             BucketCounter,
             "Test cumulative bucket counter with groups",
             ["group1", "group2"],
-            (CumulFreq, [-1.5, 0])
+            (CumulFreq, "bucket", [-1.5, 0])
         )
     }
 }

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -29,13 +29,13 @@ define_stats! {
             BucketCounter,
             "Test cumulative bucket counter",
             [],
-            (CumulFreq, "bucket", [1.5, 2.5, 3.5])
+            (CumulFreq, "bucket", [10, 20, 30])
         ),
         test_group_bucket_counter(
             BucketCounter,
             "Test cumulative bucket counter with groups",
             ["group1", "group2"],
-            (CumulFreq, "bucket", [-1.5, 0])
+            (CumulFreq, "bucket", [-8, 0])
         )
     }
 }
@@ -132,6 +132,7 @@ fn request_for_single_counter() {
                 bucket_limit: None,
                 value: 0f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -153,6 +154,7 @@ fn request_for_single_gauge() {
                 bucket_limit: None,
                 value: 0f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -175,6 +177,7 @@ fn request_for_multiple_metrics() {
                     bucket_limit: None,
                     value: 0f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -185,6 +188,7 @@ fn request_for_multiple_metrics() {
                     bucket_limit: None,
                     value: 0f64,
                 }],
+                buckets: None,
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -212,6 +216,7 @@ fn request_for_updated_metrics() {
                     bucket_limit: None,
                     value: 1f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -222,6 +227,7 @@ fn request_for_updated_metrics() {
                     bucket_limit: None,
                     value: 2f64,
                 }],
+                buckets: None,
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -240,6 +246,7 @@ fn request_for_single_counter_with_groups_but_no_values() {
             description: "Test grouped counter",
             stat_type: Counter,
             values: vec![],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -257,6 +264,7 @@ fn request_for_single_gauge_with_groups_but_no_values() {
             description: "Test grouped gauge",
             stat_type: Gauge,
             values: vec![],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -286,7 +294,8 @@ fn request_for_single_counter_with_groups_and_one_value() {
                 group_values: vec!["value one".to_string(), "100".to_string()],
                 bucket_limit: None,
                 value: 1f64,
-            }], // LCOV_EXCL_LINE Kcov bug?
+            }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -317,6 +326,7 @@ fn request_for_single_gauge_with_groups_and_one_value() {
                 bucket_limit: None,
                 value: 2f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -363,6 +373,7 @@ fn request_for_single_counter_with_groups_and_two_values() {
                     value: 2f64,
                 },
             ], // LCOV_EXCL_LINE Kcov bug?
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -382,17 +393,17 @@ fn request_for_bucket_counter_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(1f64)),
+                    bucket_limit: Some(BucketLimit::Num(1)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(2f64)),
+                    bucket_limit: Some(BucketLimit::Num(2)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(3f64)),
+                    bucket_limit: Some(BucketLimit::Num(3)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
@@ -401,6 +412,11 @@ fn request_for_bucket_counter_freq() {
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::Freq,
+                "bucket",
+                vec![1, 2, 3],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -414,15 +430,6 @@ fn request_for_bucket_counter_freq_one_value() {
 
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::Freq,
-            "bucket",
-            vec![1f64, 2f64, 3f64]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -432,17 +439,17 @@ fn request_for_bucket_counter_freq_one_value() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(1f64)),
+                    bucket_limit: Some(BucketLimit::Num(1)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(2f64)),
+                    bucket_limit: Some(BucketLimit::Num(2)),
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(3f64)),
+                    bucket_limit: Some(BucketLimit::Num(3)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
@@ -451,6 +458,11 @@ fn request_for_bucket_counter_freq_one_value() {
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::Freq,
+                "bucket",
+                vec![1, 2, 3],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -461,15 +473,6 @@ fn request_for_bucket_counter_cumul_freq() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::CumulFreq,
-            "bucket",
-            vec![1.5, 2.5, 3.5]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -479,17 +482,17 @@ fn request_for_bucket_counter_cumul_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(1.5)),
+                    bucket_limit: Some(BucketLimit::Num(10)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(2.5)),
+                    bucket_limit: Some(BucketLimit::Num(20)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_limit: Some(BucketLimit::Num(3.5)),
+                    bucket_limit: Some(BucketLimit::Num(30)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
@@ -498,6 +501,11 @@ fn request_for_bucket_counter_cumul_freq() {
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::CumulFreq,
+                "bucket",
+                vec![10, 20, 30],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -528,15 +536,6 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
 
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::CumulFreq,
-            "bucket",
-            vec![-1.5f64, 0f64]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -546,12 +545,12 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_limit: Some(BucketLimit::Num(-1.5)),
+                    bucket_limit: Some(BucketLimit::Num(-8)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_limit: Some(BucketLimit::Num(0f64)),
+                    bucket_limit: Some(BucketLimit::Num(0)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
@@ -561,12 +560,12 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_limit: Some(BucketLimit::Num(-1.5)),
+                    bucket_limit: Some(BucketLimit::Num(-8)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_limit: Some(BucketLimit::Num(0f64)),
+                    bucket_limit: Some(BucketLimit::Num(0)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
@@ -575,6 +574,11 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
                     value: 4f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::CumulFreq,
+                "bucket",
+                vec![-8, 0],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -633,6 +637,7 @@ fn request_for_many_metrics() {
                     bucket_limit: None,
                     value: 1f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -643,6 +648,7 @@ fn request_for_many_metrics() {
                     bucket_limit: None,
                     value: 2f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_counter",
@@ -660,6 +666,7 @@ fn request_for_many_metrics() {
                         value: 4f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_gauge",
@@ -677,6 +684,7 @@ fn request_for_many_metrics() {
                         value: 6f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_freq",
@@ -685,17 +693,17 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(1f64)),
+                        bucket_limit: Some(BucketLimit::Num(1)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(2f64)),
+                        bucket_limit: Some(BucketLimit::Num(2)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(3f64)),
+                        bucket_limit: Some(BucketLimit::Num(3)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
@@ -704,6 +712,11 @@ fn request_for_many_metrics() {
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::Freq,
+                    "bucket",
+                    vec![1, 2, 3],
+                )),
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_cumul_freq",
@@ -712,17 +725,17 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(1.5)),
+                        bucket_limit: Some(BucketLimit::Num(10)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(2.5)),
+                        bucket_limit: Some(BucketLimit::Num(20)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(3.5)),
+                        bucket_limit: Some(BucketLimit::Num(30)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
@@ -731,6 +744,11 @@ fn request_for_many_metrics() {
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::CumulFreq,
+                    "bucket",
+                    vec![10, 20, 30],
+                )),
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_cumul_freq",
@@ -739,17 +757,17 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(1.5)),
+                        bucket_limit: Some(BucketLimit::Num(10)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(2.5)),
+                        bucket_limit: Some(BucketLimit::Num(20)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_limit: Some(BucketLimit::Num(3.5)),
+                        bucket_limit: Some(BucketLimit::Num(30)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
@@ -758,6 +776,11 @@ fn request_for_many_metrics() {
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::CumulFreq,
+                    "bucket",
+                    vec![10, 20, 30],
+                )),
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -129,7 +129,7 @@ fn request_for_single_counter() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 0f64,
             }],
         }],
@@ -150,7 +150,7 @@ fn request_for_single_gauge() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 0f64,
             }],
         }],
@@ -172,7 +172,7 @@ fn request_for_multiple_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 0f64,
                 }],
             },
@@ -182,7 +182,7 @@ fn request_for_multiple_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 0f64,
                 }],
             },
@@ -209,7 +209,7 @@ fn request_for_updated_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 }],
             },
@@ -219,7 +219,7 @@ fn request_for_updated_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 }],
             },
@@ -284,7 +284,7 @@ fn request_for_single_counter_with_groups_and_one_value() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value one".to_string(), "100".to_string()],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 1f64,
             }], // LCOV_EXCL_LINE Kcov bug?
         }],
@@ -314,7 +314,7 @@ fn request_for_single_gauge_with_groups_and_one_value() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value two".to_string(), "200".to_string()],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 2f64,
             }],
         }],
@@ -354,12 +354,12 @@ fn request_for_single_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value one".to_string(), "100".to_string()],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value two".to_string(), "200".to_string()],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 },
             ], // LCOV_EXCL_LINE Kcov bug?
@@ -382,22 +382,22 @@ fn request_for_bucket_counter_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(1f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(2f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(3f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
@@ -432,22 +432,22 @@ fn request_for_bucket_counter_freq_one_value() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(1f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(2f64)),
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(3f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
@@ -479,22 +479,22 @@ fn request_for_bucket_counter_cumul_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(1.5)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(2.5)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(3.5)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
@@ -546,32 +546,32 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(-1.5)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(0f64)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 3f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(-1.5)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(0f64)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 4f64,
                 },
             ],
@@ -630,7 +630,7 @@ fn request_for_many_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 }],
             },
@@ -640,7 +640,7 @@ fn request_for_many_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 }],
             },
@@ -651,12 +651,12 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value one".to_string(), "100".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 3f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value two".to_string(), "200".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 4f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
@@ -668,12 +668,12 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value three".to_string(), "300".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 5f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value four".to_string(), "400".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 6f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
@@ -685,49 +685,22 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(0),
+                        bucket_limit: Some(BucketLimit::Num(1f64)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(1),
+                        bucket_limit: Some(BucketLimit::Num(2f64)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Num(3f64)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
-                        value: 0f64,
-                    },
-                ],
-            },
-            ExpectedStatSnapshot {
-                name: "test_bucket_counter_cumul_freq",
-                description: "Test cumulative bucket counter",
-                stat_type: BucketCounter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        bucket_index: Some(0),
-                        value: 0f64,
-                    },
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        bucket_index: Some(1),
-                        value: 0f64,
-                    },
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        bucket_index: Some(2),
-                        value: 0f64,
-                    },
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Unbounded),
                         value: 0f64,
                     },
                 ],
@@ -739,22 +712,49 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(0),
+                        bucket_limit: Some(BucketLimit::Num(1.5)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(1),
+                        bucket_limit: Some(BucketLimit::Num(2.5)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Num(3.5)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Unbounded),
+                        value: 0f64,
+                    },
+                ],
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_cumul_freq",
+                description: "Test cumulative bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_limit: Some(BucketLimit::Num(1.5)),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_limit: Some(BucketLimit::Num(2.5)),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_limit: Some(BucketLimit::Num(3.5)),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_limit: Some(BucketLimit::Unbounded),
                         value: 0f64,
                     },
                 ],

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -415,7 +415,7 @@ fn request_for_bucket_counter_freq() {
             buckets: Some(Buckets::new(
                 BucketMethod::Freq,
                 "bucket",
-                vec![1, 2, 3],
+                &vec![1, 2, 3],
             )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -461,7 +461,7 @@ fn request_for_bucket_counter_freq_one_value() {
             buckets: Some(Buckets::new(
                 BucketMethod::Freq,
                 "bucket",
-                vec![1, 2, 3],
+                &vec![1, 2, 3],
             )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -504,7 +504,7 @@ fn request_for_bucket_counter_cumul_freq() {
             buckets: Some(Buckets::new(
                 BucketMethod::CumulFreq,
                 "bucket",
-                vec![10, 20, 30],
+                &vec![10, 20, 30],
             )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -577,7 +577,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             buckets: Some(Buckets::new(
                 BucketMethod::CumulFreq,
                 "bucket",
-                vec![-8, 0],
+                &vec![-8, 0],
             )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -715,7 +715,7 @@ fn request_for_many_metrics() {
                 buckets: Some(Buckets::new(
                     BucketMethod::Freq,
                     "bucket",
-                    vec![1, 2, 3],
+                    &vec![1, 2, 3],
                 )),
             },
             ExpectedStatSnapshot {
@@ -747,7 +747,7 @@ fn request_for_many_metrics() {
                 buckets: Some(Buckets::new(
                     BucketMethod::CumulFreq,
                     "bucket",
-                    vec![10, 20, 30],
+                    &vec![10, 20, 30],
                 )),
             },
             ExpectedStatSnapshot {
@@ -779,7 +779,7 @@ fn request_for_many_metrics() {
                 buckets: Some(Buckets::new(
                     BucketMethod::CumulFreq,
                     "bucket",
-                    vec![10, 20, 30],
+                    &vec![10, 20, 30],
                 )),
             },
         ], // LCOV_EXCL_LINE Kcov bug?

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -14,7 +14,7 @@ extern crate slog_extlog_derive;
 
 use slog_extlog::slog_test::*;
 use slog_extlog::stats;
-use slog_extlog::stats::StatType::{Counter, Gauge};
+use slog_extlog::stats::StatType::{BucketCounter, Counter, Gauge};
 use std::str;
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_QUERY_TEST";
@@ -24,7 +24,10 @@ define_stats! {
         test_counter(Counter, "Test counter", []),
         test_gauge(Gauge, "Test gauge", []),
         test_grouped_counter(Counter, "Test grouped counter", ["counter_group_one", "counter_group_two"]),
-        test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"])
+        test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"]),
+        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, [1, 2, 3])),
+        test_bucket_counter_cumul_freq(BucketCounter, "Test cumulative bucket counter", [], (CumulFreq, [1.5, 2.5, 3.5])),
+        test_group_bucket_counter(BucketCounter, "Test cumulative bucket counter with groups", ["group1", "group2"], (CumulFreq, [-1.5, 0]))
     }
 }
 
@@ -55,7 +58,7 @@ struct GroupedCounterUpdateLog {
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(Id = "3", Text = "Amount sent", Level = "Info")]
+#[LogDetails(Id = "4", Text = "Amount sent", Level = "Info")]
 #[StatTrigger(StatName = "test_grouped_gauge", Action = "Incr", ValueFrom = "self.delta")]
 struct GroupedGaugeUpdateLog {
     delta: i32,
@@ -63,6 +66,35 @@ struct GroupedGaugeUpdateLog {
     gauge_group_one: String,
     #[StatGroup(StatName = "test_grouped_gauge")]
     gauge_group_two: u32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "5", Text = "test bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_bucket_counter_freq", Action = "Incr", Value = "1")]
+struct BucketCounterLog {
+    #[BucketBy(StatName = "test_bucket_counter_freq")]
+    bucket_value: f32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "5", Text = "cumulative test bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_bucket_counter_cumul_freq", Action = "Incr", Value = "2")]
+struct CumulBucketCounterLog {
+    #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
+    bucket_value: f32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "6", Text = "test grouped bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_group_bucket_counter", Action = "Incr", ValueFrom = "self.delta")]
+struct GroupBucketCounterLog {
+    delta: i32,
+    #[StatGroup(StatName = "test_group_bucket_counter")]
+    group1: String,
+    #[StatGroup(StatName = "test_group_bucket_counter")]
+    group2: String,
+    #[BucketBy(StatName = "test_group_bucket_counter")]
+    bucket_value: f32,
 }
 //LCOV_EXCL_STOP
 
@@ -88,6 +120,7 @@ fn request_for_single_counter() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
+                bucket_index: None,
                 value: 0f64,
             }],
         }],
@@ -108,6 +141,7 @@ fn request_for_single_gauge() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
+                bucket_index: None,
                 value: 0f64,
             }],
         }],
@@ -129,6 +163,7 @@ fn request_for_multiple_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 0f64,
                 }],
             },
@@ -138,6 +173,7 @@ fn request_for_multiple_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 0f64,
                 }],
             },
@@ -164,6 +200,7 @@ fn request_for_updated_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 1f64,
                 }],
             },
@@ -173,6 +210,7 @@ fn request_for_updated_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 2f64,
                 }],
             },
@@ -237,6 +275,7 @@ fn request_for_single_counter_with_groups_and_one_value() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value one".to_string(), "100".to_string()],
+                bucket_index: None,
                 value: 1f64,
             }], // LCOV_EXCL_LINE Kcov bug?
         }],
@@ -266,6 +305,7 @@ fn request_for_single_gauge_with_groups_and_one_value() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value two".to_string(), "200".to_string()],
+                bucket_index: None,
                 value: 2f64,
             }],
         }],
@@ -305,13 +345,216 @@ fn request_for_single_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value one".to_string(), "100".to_string()],
+                    bucket_index: None,
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value two".to_string(), "200".to_string()],
+                    bucket_index: None,
                     value: 2f64,
                 },
             ], // LCOV_EXCL_LINE Kcov bug?
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_freq() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+    let stats = logger.get_stats();
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_freq",
+            description: "Test bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+
+#[test]
+fn request_for_bucket_counter_freq_one_value() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+
+    xlog!(logger, BucketCounterLog { bucket_value: 1.5 });
+
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(BucketMethod::Freq, vec![1f64, 2f64, 3f64]))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_freq",
+            description: "Test bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 1f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_cumul_freq() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_cumul_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(BucketMethod::CumulFreq, vec![1.5, 2.5, 3.5]))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_cumul_freq",
+            description: "Test cumulative bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_with_groups_and_two_values() {
+    static STATS: StatDefinitions = &[&test_group_bucket_counter];
+    let (logger, _) = create_logger_buffer(STATS);
+
+    xlog!(
+        logger,
+        GroupBucketCounterLog {
+            delta: 3,
+            group1: "one".to_string(),
+            group2: "two".to_string(),
+            bucket_value: 7.4
+        }
+    );
+    xlog!(
+        logger,
+        GroupBucketCounterLog {
+            delta: 4,
+            group1: "three".to_string(),
+            group2: "four".to_string(),
+            bucket_value: -20f32
+        }
+    );
+
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(BucketMethod::CumulFreq, vec![-1.5f64, 0f64,]))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_group_bucket_counter",
+            description: "Test cumulative bucket counter with groups",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(),"two".to_string()],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(),"two".to_string()],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(),"two".to_string()],
+                    bucket_index: Some(2),
+                    value: 3f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(),"four".to_string()],
+                    bucket_index: Some(0),
+                    value: 4f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(),"four".to_string()],
+                    bucket_index: Some(1),
+                    value: 4f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(),"four".to_string()],
+                    bucket_index: Some(2),
+                    value: 4f64,
+                },
+            ],
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -358,6 +601,7 @@ fn request_for_many_metrics() {
     );
 
     let stats = logger.get_stats();
+    println!("stats: {:?}", stats);
     check_expected_stat_snaphots(
         &stats,
         &vec![
@@ -367,6 +611,7 @@ fn request_for_many_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 1f64,
                 }],
             },
@@ -376,6 +621,7 @@ fn request_for_many_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
+                    bucket_index: None,
                     value: 2f64,
                 }],
             },
@@ -386,10 +632,12 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value one".to_string(), "100".to_string()],
+                        bucket_index: None,
                         value: 3f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value two".to_string(), "200".to_string()],
+                        bucket_index: None,
                         value: 4f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
@@ -401,13 +649,96 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value three".to_string(), "300".to_string()],
+                        bucket_index: None,
                         value: 5f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value four".to_string(), "400".to_string()],
+                        bucket_index: None,
                         value: 6f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_freq",
+                description: "Test bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_cumul_freq",
+                description: "Test cumulative bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_cumul_freq",
+                description: "Test cumulative bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -26,8 +26,18 @@ define_stats! {
         test_grouped_counter(Counter, "Test grouped counter", ["counter_group_one", "counter_group_two"]),
         test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"]),
         test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, [1, 2, 3])),
-        test_bucket_counter_cumul_freq(BucketCounter, "Test cumulative bucket counter", [], (CumulFreq, [1.5, 2.5, 3.5])),
-        test_group_bucket_counter(BucketCounter, "Test cumulative bucket counter with groups", ["group1", "group2"], (CumulFreq, [-1.5, 0]))
+        test_bucket_counter_cumul_freq(
+            BucketCounter,
+            "Test cumulative bucket counter",
+            [],
+            (CumulFreq, [1.5, 2.5, 3.5])
+        ),
+        test_group_bucket_counter(
+            BucketCounter,
+            "Test cumulative bucket counter with groups",
+            ["group1", "group2"],
+            (CumulFreq, [-1.5, 0])
+        )
     }
 }
 

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -621,7 +621,6 @@ fn request_for_many_metrics() {
     );
 
     let stats = logger.get_stats();
-    println!("stats: {:?}", stats);
     check_expected_stat_snaphots(
         &stats,
         &vec![

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -406,7 +406,6 @@ fn request_for_bucket_counter_freq() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-
 #[test]
 fn request_for_bucket_counter_freq_one_value() {
     static STATS: StatDefinitions = &[&test_bucket_counter_freq];
@@ -524,7 +523,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
 
     assert_eq!(
         stats[0].definition.buckets(),
-        Some(Buckets::new(BucketMethod::CumulFreq, vec![-1.5f64, 0f64,]))
+        Some(Buckets::new(BucketMethod::CumulFreq, vec![-1.5f64, 0f64]))
     );
 
     check_expected_stat_snaphots(
@@ -535,32 +534,32 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             stat_type: BucketCounter,
             values: vec![
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["one".to_string(),"two".to_string()],
+                    group_values: vec!["one".to_string(), "two".to_string()],
                     bucket_index: Some(0),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["one".to_string(),"two".to_string()],
+                    group_values: vec!["one".to_string(), "two".to_string()],
                     bucket_index: Some(1),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["one".to_string(),"two".to_string()],
+                    group_values: vec!["one".to_string(), "two".to_string()],
                     bucket_index: Some(2),
                     value: 3f64,
                 },
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["three".to_string(),"four".to_string()],
+                    group_values: vec!["three".to_string(), "four".to_string()],
                     bucket_index: Some(0),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["three".to_string(),"four".to_string()],
+                    group_values: vec!["three".to_string(), "four".to_string()],
                     bucket_index: Some(1),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
-                    group_values: vec!["three".to_string(),"four".to_string()],
+                    group_values: vec!["three".to_string(), "four".to_string()],
                     bucket_index: Some(2),
                     value: 4f64,
                 },

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -1,5 +1,4 @@
 //! Tests for querying the current values of stats.
-//!
 
 extern crate futures;
 
@@ -507,7 +506,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             group1: "one".to_string(),
             group2: "two".to_string(),
             bucket_value: 7.4
-        }
+        } // LCOV_EXCL_LINE Kcov bug?
     );
     xlog!(
         logger,
@@ -516,7 +515,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             group1: "three".to_string(),
             group2: "four".to_string(),
             bucket_value: -20f32
-        }
+        } // LCOV_EXCL_LINE Kcov bug?
     );
 
     let stats = logger.get_stats();

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -82,19 +82,15 @@ fn request_for_single_counter() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_counter",
-                description: "Test counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_counter",
+            description: "Test counter",
+            stat_type: Counter,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec![],
+                value: 0f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -106,19 +102,15 @@ fn request_for_single_gauge() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_gauge",
-                description: "Test gauge",
-                stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_gauge",
+            description: "Test gauge",
+            stat_type: Gauge,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec![],
+                value: 0f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -135,23 +127,19 @@ fn request_for_multiple_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 0f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 0f64,
+                }],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -174,23 +162,19 @@ fn request_for_updated_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 1f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 1f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 2f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 2f64,
+                }],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -204,14 +188,12 @@ fn request_for_single_counter_with_groups_but_no_values() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -223,14 +205,12 @@ fn request_for_single_gauge_with_groups_but_no_values() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_gauge",
-                description: "Test grouped gauge",
-                stat_type: Gauge,
-                values: vec![],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_gauge",
+            description: "Test grouped gauge",
+            stat_type: Gauge,
+            values: vec![],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -251,19 +231,15 @@ fn request_for_single_counter_with_groups_and_one_value() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value one".to_string(), "100".to_string()],
-                        value: 1f64,
-                    },
-                ], // LCOV_EXCL_LINE Kcov bug?
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec!["value one".to_string(), "100".to_string()],
+                value: 1f64,
+            }], // LCOV_EXCL_LINE Kcov bug?
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -284,19 +260,15 @@ fn request_for_single_gauge_with_groups_and_one_value() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_gauge",
-                description: "Test grouped gauge",
-                stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value two".to_string(), "200".to_string()],
-                        value: 2f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_gauge",
+            description: "Test grouped gauge",
+            stat_type: Gauge,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec!["value two".to_string(), "200".to_string()],
+                value: 2f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -326,23 +298,21 @@ fn request_for_single_counter_with_groups_and_two_values() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value one".to_string(), "100".to_string()],
-                        value: 1f64,
-                    },
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value two".to_string(), "200".to_string()],
-                        value: 2f64,
-                    },
-                ], // LCOV_EXCL_LINE Kcov bug?
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["value one".to_string(), "100".to_string()],
+                    value: 1f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["value two".to_string(), "200".to_string()],
+                    value: 2f64,
+                },
+            ], // LCOV_EXCL_LINE Kcov bug?
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -395,23 +365,19 @@ fn request_for_many_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 1f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 1f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 2f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    value: 2f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_counter",


### PR DESCRIPTION
**!! Superseded by https://github.com/slog-rs/extlog/pull/7 !!**

This adds a new `BucketCounter` stat type, which sorts logged stats into buckets based on a numerical value.
- The `define_stats!` macro is updated to accept the `BucketCounter` stat type and to take the additional parameters that it requires: An enum value that determines how values should be sorted into buckets, a label name describing what the buckets measure, and a list of `f64`s defining the bucket boundaries. This is a backwards compatible change.
- The `StatSnapshot` struct is updated to contain information about the bucketed values. This is a breaking change.
- The `StatLogData` struct is unchanged, and treats the buckets as additional tags, with the tag name given by the bucket label name.