### PR TITLE
Histograms2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 ### Added
+
+## [5.0.0]
+### Changed
+### Added
 - Add the `BucketCounter` stat type for tracking stats grouped into numerical ranges.
 
 ## [4.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+### Added
+- Add the `BucketCounter` stat type for tracking stats grouped into numerical ranges.
 
 ## [4.1.0]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "4.1.0"
+version = "5.0.0"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
 homepage = "https://github.com/slog-rs/extlog"
@@ -42,7 +42,7 @@ bencher = "0.1.5"
 # This is a known problem in Cargo - see
 # https://github.com/rust-lang/cargo/issues/4242 for tracking issue.
 [dev-dependencies.slog-extlog-derive]
-version = "4.1"
+version = "5"
 path = "slog-extlog-derive"
 
 [workspace]

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-extlog-derive"
-version = "4.1.0"
+version = "5.0.0"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"
@@ -13,7 +13,7 @@ readme = "../README.md"
 slog =  { version = "2.1", features = ['nested-values'] }
 syn = {version = "0.11.9", features = ["full"] }
 quote = "0.3.10"
-slog-extlog = { version = "4.1", path = ".." }
+slog-extlog = { version = "5", path = ".." }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -113,6 +113,7 @@
 //!
 //! use slog_extlog::{ExtLoggable, stats};
 //! use slog_extlog::stats::StatDefinition;
+//! use slog_extlog::stats::Buckets;
 //!
 //! // The prefix to add to all log identifiers.
 //! const CRATE_LOG_NAME: &'static str = "FOO";
@@ -208,6 +209,7 @@ struct StatTriggerData {
     action: StatTriggerAction,
     val: StatTriggerValue,
     group_by: Vec<syn::Ident>,
+    bucket_by: Option<syn::Ident>,
 }
 
 /// Generate implementations of the `slog::Value` trait.
@@ -231,7 +233,9 @@ pub fn slog_value(input: TokenStream) -> TokenStream {
 /// Generate implementations of the [`ExtLoggable`](../slog_extlog/trait.ExtLoggable.html) trait.
 ///
 /// Do not call this function directly.  Use `#[derive]` instead.
-#[proc_macro_derive(ExtLoggable, attributes(LogDetails, FixedFields, StatTrigger, StatGroup))]
+#[proc_macro_derive(
+    ExtLoggable, attributes(LogDetails, FixedFields, StatTrigger, StatGroup, BucketBy)
+)]
 pub fn loggable(input: TokenStream) -> TokenStream {
     // Construct a string representation of the type definition
     let s = input.to_string();
@@ -318,7 +322,7 @@ fn get_types_bounds(
 }
 
 fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
-    // Get stat triggering details.roups.
+    // Get stat triggering details.
     let triggers = ast.attrs
         .iter()
         .filter(|a| a.name() == "StatTrigger")
@@ -381,6 +385,23 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         }
     }
 
+    // Build up the bucket info for each stat.
+    let mut stats_buckets = quote!{};
+    for t in &triggers {
+        let id = &t.id.to_string();
+        let bucket = t.bucket_by.clone();
+        if let Some(bucket) = bucket {
+            // let bucket_str = bucket.to_string();
+            stats_buckets = quote! { #stats_buckets
+                #id => Some(self.#bucket as f64),
+            }
+        } else {
+            stats_buckets = quote! { #stats_buckets
+                #id => None,
+            }
+        }
+    }
+
     // Tweak to ensure we avoid unused variable warnings in `get_tag_value()`.
     let tag_name_ident = if !triggers.is_empty() {
         quote! { tag_name }
@@ -438,6 +459,15 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
                 match stat_id.name() {
                     #stats_groups
                     _ => "".to_string(),
+                }
+            }
+
+            /// The value to be used to sort the stat into buckets
+            fn bucket_value(&self,
+                         stat_id: &::slog_extlog::stats::StatDefinition) -> Option<f64> {
+                match stat_id.name() {
+                    # stats_buckets
+                    _ => None,
                 }
             }
         }
@@ -682,11 +712,36 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
     let groups = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
         fields
             .iter()
-            .filter(|f| f.attrs.iter().any(|a| is_attr_stat_id(a, &id)))
+            .filter(|f| {
+                f.attrs
+                    .iter()
+                    .any(|a| a.name() == "StatGroup" && is_attr_stat_id(a, &id))
+            })
             .map(|f| f.clone().ident.expect("No identifier for field!"))
             .collect::<Vec<_>>()
     } else {
         vec![]
+    };
+
+    let bucket_field = if let syn::Body::Struct(syn::VariantData::Struct(ref all_fields)) = *body {
+        let bucket_by_fields = all_fields
+            .iter()
+            .filter(|f| {
+                f.attrs
+                    .iter()
+                    .any(|a| a.name() == "BucketBy" && is_attr_stat_id(a, &id))
+            })
+            .map(|f| f.clone().ident.expect("No identifier for field!"))
+            .collect::<Vec<_>>();
+
+        assert!(
+            bucket_by_fields.len() <= 1,
+            "The BucketBy attribute can be added to at most one field"
+        );
+
+        bucket_by_fields.into_iter().next()
+    } else {
+        None
     };
 
     StatTriggerData {
@@ -697,6 +752,7 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
         action: action.expect("StatTrigger missing value for Action"),
         val: value.expect("StatTrigger missing value for Value or ValueFrom"),
         group_by: groups,
+        bucket_by: bucket_field,
     }
 }
 // LCOV_EXCL_STOP

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -391,13 +391,8 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         let id = &t.id.to_string();
         let bucket = t.bucket_by.clone();
         if let Some(bucket) = bucket {
-            // let bucket_str = bucket.to_string();
             stats_buckets = quote! { #stats_buckets
                 #id => Some(self.#bucket as f64),
-            }
-        } else {
-            stats_buckets = quote! { #stats_buckets
-                #id => None,
             }
         }
     }
@@ -734,10 +729,9 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
             .map(|f| f.clone().ident.expect("No identifier for field!"))
             .collect::<Vec<_>>();
 
-        assert!(
-            bucket_by_fields.len() <= 1,
-            "The BucketBy attribute can be added to at most one field"
-        );
+        if bucket_by_fields.len() > 1 {
+            panic!("The BucketBy attribute can be added to at most one field");
+        }
 
         bucket_by_fields.into_iter().next()
     } else {

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -17,8 +17,8 @@ extern crate slog_extlog_derive;
 extern crate erased_serde;
 
 use slog::Logger;
-use slog_extlog::DefaultLogger;
 use slog_extlog::slog_test;
+use slog_extlog::DefaultLogger;
 use std::str;
 
 const CRATE_LOG_NAME: &str = "SLOGTST";

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -10,7 +10,6 @@ extern crate slog_extlog;
 #[macro_use]
 extern crate slog_extlog_derive;
 
-use slog_extlog::stats::*;
 use slog_extlog::slog_test::*;
 use std::{panic, thread, time};
 
@@ -27,7 +26,10 @@ define_stats! {
         test_grouped_counter(Counter, "Test counter grouped by name", ["name"]),
         test_double_grouped(Counter, "Test counter grouped by type and error",
                                ["name", "error"]),
-        test_latest_foo_error_count(Counter, "Latest foo error byte count", [])
+        test_latest_foo_error_count(Counter, "Latest foo error byte count", []),
+        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, "bucket", [1,2,3,4])),
+        test_bucket_counter_cumul_freq(BucketCounter, "Test cumulative bucket counter", [], (CumulFreq, "bucket", [1,2,3,4])),
+        test_bucket_counter_grouped(BucketCounter, "Test bucket counter grouped by name and error", ["name", "error"], (Freq, "bucket", [-5, 5]))
     }
 }
 
@@ -35,10 +37,15 @@ define_stats! {
 #[LogDetails(Id = "1", Text = "Amount sent", Level = "Info")]
 #[StatTrigger(StatName = "test_counter", Action = "Incr", Value = "1")]
 #[StatTrigger(StatName = "test_second_counter", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_gauge", Condition = "self.bytes < 200", Action = "Incr",
-              Value = "1")]
-#[StatTrigger(StatName = "test_second_gauge", Condition = "self.bytes > self.unbytes as u32",
-              Action = "Incr", ValueFrom = "self.bytes - (self.unbytes as u32)")]
+#[StatTrigger(
+    StatName = "test_gauge", Condition = "self.bytes < 200", Action = "Incr", Value = "1"
+)]
+#[StatTrigger(
+    StatName = "test_second_gauge",
+    Condition = "self.bytes > self.unbytes as u32",
+    Action = "Incr",
+    ValueFrom = "self.bytes - (self.unbytes as u32)"
+)]
 //LCOV_EXCL_START
 struct ExternalLog {
     bytes: u32,
@@ -47,16 +54,18 @@ struct ExternalLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "2", Text = "Some floating point number", Level = "Error")]
-#[StatTrigger(StatName = "test_gauge", Condition = "self.floating > 1.0", Action = "Decr",
-              Value = "1")]
+#[StatTrigger(
+    StatName = "test_gauge", Condition = "self.floating > 1.0", Action = "Decr", Value = "1"
+)]
 struct SecondExternalLog {
     floating: f32,
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "3", Text = "A string of text", Level = "Warning")]
-#[StatTrigger(StatName = "test_foo_count", Condition = "self.name == \"foo\"", Action = "Incr",
-              Value = "1")]
+#[StatTrigger(
+    StatName = "test_foo_count", Condition = "self.name == \"foo\"", Action = "Incr", Value = "1"
+)]
 #[StatTrigger(StatName = "test_grouped_counter", Action = "Incr", Value = "1")]
 struct ThirdExternalLog {
     #[StatGroup(StatName = "test_grouped_counter")]
@@ -66,8 +75,12 @@ struct ThirdExternalLog {
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "4", Text = "Some more irrelevant text", Level = "Info")]
 #[StatTrigger(StatName = "test_double_grouped", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_latest_foo_error_count", Condition = "self.error != 0",
-              Action = "SetVal", ValueFrom = "self.foo_count")]
+#[StatTrigger(
+    StatName = "test_latest_foo_error_count",
+    Condition = "self.error != 0",
+    Action = "SetVal",
+    ValueFrom = "self.foo_count"
+)]
 struct FourthExternalLog {
     #[StatGroup(StatName = "test_double_grouped")]
     name: String,
@@ -75,7 +88,29 @@ struct FourthExternalLog {
     #[StatGroup(StatName = "test_double_grouped")]
     error: u8,
 }
-//LCOV_EXCL_STOP
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "5", Text = "Some floating point number", Level = "Error")]
+#[StatTrigger(StatName = "test_bucket_counter_freq", Action = "Incr", Value = "1")]
+#[StatTrigger(StatName = "test_bucket_counter_cumul_freq", Action = "Incr", Value = "1")]
+struct FifthExternalLog {
+    #[BucketBy(StatName = "test_bucket_counter_freq")]
+    #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
+    floating: f32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "6", Text = "Some floating point number with name and error", Level = "Error")]
+#[StatTrigger(StatName = "test_bucket_counter_grouped", Action = "Incr", Value = "1")]
+struct SixthExternalLog {
+    #[StatGroup(StatName = "test_bucket_counter_grouped")]
+    name: String,
+    #[StatGroup(StatName = "test_bucket_counter_grouped")]
+    error: u8,
+    #[BucketBy(StatName = "test_bucket_counter_grouped")]
+    floating: f32,
+}
+// LCOV_EXCL_STOP
 
 // Shortcut for a standard external log of the first struct with given values.
 fn log_external_stat(
@@ -86,7 +121,7 @@ fn log_external_stat(
     xlog!(logger, ExternalLog { bytes, unbytes });
 }
 
-// Shortcut for a standard external log of the fifourthrst struct with given values.
+// Shortcut for a standard external log of the fourth struct with given values.
 fn log_external_grouped(
     logger: &StatisticsLogger<DefaultStatisticsLogFormatter>,
     name: String,
@@ -271,11 +306,13 @@ fn basic_extloggable_grouped_by_string() {
                 stat_name: "test_grouped_counter",
                 tag: Some("name=bar"),
                 value: 4f64,
+                metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_grouped_counter",
                 tag: Some("name=foo"),
                 value: 2f64,
+                metric_type: "counter",
             },
         ],
     );
@@ -303,26 +340,342 @@ fn basic_extloggable_grouped_by_mixed() {
                 stat_name: "test_double_grouped",
                 tag: Some("name=bar,error=0"),
                 value: 2f64,
+                metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=0"),
                 value: 1f64,
+                metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=bar,error=1"),
                 value: 1f64,
+                metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=2"),
                 value: 1f64,
+                metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=bar,error=2"),
                 value: 1f64,
+                metric_type: "counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_bucket_counter_freq() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(logger, FifthExternalLog { floating: 2.5 });
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
+    assert_eq!(logs.len(), 5);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=1"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=2"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=3"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=4"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=Unbounded"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_bucket_counter_freq_high_value() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(
+        logger,
+        FifthExternalLog {
+            floating: 10 as f32
+        }
+    );
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
+    assert_eq!(logs.len(), 5);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=1"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=2"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=3"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=4"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_freq",
+                tag: Some("bucket=Unbounded"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_bucket_counter_cumul_freq() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(logger, FifthExternalLog { floating: 2.5 });
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_cumul_freq", &mut data);
+    assert_eq!(logs.len(), 5);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=1"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=2"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=3"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=4"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=Unbounded"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_bucket_counter_cumul_freq_high_value() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(logger, FifthExternalLog { floating: 8 as f32 });
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_cumul_freq", &mut data);
+    assert_eq!(logs.len(), 5);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=1"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=2"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=3"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=4"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_cumul_freq",
+                tag: Some("bucket=Unbounded"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_buckets_and_repeated_tags() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "name".to_string(),
+            error: 3,
+            floating: -1f32
+        }
+    );
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "name".to_string(),
+            error: 3,
+            floating: 7f32
+        }
+    );
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_grouped", &mut data);
+    assert_eq!(logs.len(), 3);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3,bucket=-5"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3,bucket=5"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=name,error=3,bucket=Unbounded"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_extloggable_bucket_counter_grouped() {
+    let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "first".to_string(),
+            error: 1,
+            floating: -7 as f32
+        }
+    );
+    xlog!(
+        logger,
+        SixthExternalLog {
+            name: "second".to_string(),
+            error: 2,
+            floating: 3.7634 as f32
+        }
+    );
+
+    // Wait for the stats logs.
+    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    let logs = get_stat_logs("test_bucket_counter_grouped", &mut data);
+    assert_eq!(logs.len(), 6);
+
+    check_expected_stats(
+        &logs,
+        vec![
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=first,error=1,bucket=-5"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=first,error=1,bucket=5"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=first,error=1,bucket=Unbounded"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=second,error=2,bucket=-5"),
+                value: 0f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=second,error=2,bucket=5"),
+                value: 1f64,
+                metric_type: "bucket counter",
+            },
+            ExpectedStat {
+                stat_name: "test_bucket_counter_grouped",
+                tag: Some("name=second,error=2,bucket=Unbounded"),
+                value: 0f64,
+                metric_type: "bucket counter",
             },
         ],
     );

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -1,5 +1,4 @@
 //! Tests for querying the current values of stats.
-//!
 
 extern crate futures;
 
@@ -14,7 +13,7 @@ extern crate slog_extlog_derive;
 
 use slog_extlog::slog_test::*;
 use slog_extlog::stats;
-use slog_extlog::stats::StatType::{Counter, Gauge};
+use slog_extlog::stats::StatType::{BucketCounter, Counter, Gauge};
 use std::str;
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_QUERY_TEST";
@@ -24,7 +23,20 @@ define_stats! {
         test_counter(Counter, "Test counter", []),
         test_gauge(Gauge, "Test gauge", []),
         test_grouped_counter(Counter, "Test grouped counter", ["counter_group_one", "counter_group_two"]),
-        test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"])
+        test_grouped_gauge(Gauge, "Test grouped gauge", ["gauge_group_one", "gauge_group_two"]),
+        test_bucket_counter_freq(BucketCounter, "Test bucket counter", [], (Freq, "bucket", [1, 2, 3])),
+        test_bucket_counter_cumul_freq(
+            BucketCounter,
+            "Test cumulative bucket counter",
+            [],
+            (CumulFreq, "bucket", [1.5, 2.5, 3.5])
+        ),
+        test_group_bucket_counter(
+            BucketCounter,
+            "Test cumulative bucket counter with groups",
+            ["group1", "group2"],
+            (CumulFreq, "bucket", [-1.5, 0])
+        )
     }
 }
 
@@ -55,7 +67,7 @@ struct GroupedCounterUpdateLog {
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(Id = "3", Text = "Amount sent", Level = "Info")]
+#[LogDetails(Id = "4", Text = "Amount sent", Level = "Info")]
 #[StatTrigger(StatName = "test_grouped_gauge", Action = "Incr", ValueFrom = "self.delta")]
 struct GroupedGaugeUpdateLog {
     delta: i32,
@@ -63,6 +75,35 @@ struct GroupedGaugeUpdateLog {
     gauge_group_one: String,
     #[StatGroup(StatName = "test_grouped_gauge")]
     gauge_group_two: u32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "5", Text = "test bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_bucket_counter_freq", Action = "Incr", Value = "1")]
+struct BucketCounterLog {
+    #[BucketBy(StatName = "test_bucket_counter_freq")]
+    bucket_value: f32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "5", Text = "cumulative test bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_bucket_counter_cumul_freq", Action = "Incr", Value = "2")]
+struct CumulBucketCounterLog {
+    #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
+    bucket_value: f32,
+}
+
+#[derive(ExtLoggable, Clone, Serialize)]
+#[LogDetails(Id = "6", Text = "test grouped bucket counter stat log", Level = "Info")]
+#[StatTrigger(StatName = "test_group_bucket_counter", Action = "Incr", ValueFrom = "self.delta")]
+struct GroupBucketCounterLog {
+    delta: i32,
+    #[StatGroup(StatName = "test_group_bucket_counter")]
+    group1: String,
+    #[StatGroup(StatName = "test_group_bucket_counter")]
+    group2: String,
+    #[BucketBy(StatName = "test_group_bucket_counter")]
+    bucket_value: f32,
 }
 //LCOV_EXCL_STOP
 
@@ -82,19 +123,16 @@ fn request_for_single_counter() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_counter",
-                description: "Test counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_counter",
+            description: "Test counter",
+            stat_type: Counter,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec![],
+                bucket_index: None,
+                value: 0f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -106,19 +144,16 @@ fn request_for_single_gauge() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_gauge",
-                description: "Test gauge",
-                stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_gauge",
+            description: "Test gauge",
+            stat_type: Gauge,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec![],
+                bucket_index: None,
+                value: 0f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -135,23 +170,21 @@ fn request_for_multiple_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 0f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 0f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 0f64,
+                }],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -174,23 +207,21 @@ fn request_for_updated_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 1f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 1f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 2f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 2f64,
+                }],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -204,14 +235,12 @@ fn request_for_single_counter_with_groups_but_no_values() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -223,14 +252,12 @@ fn request_for_single_gauge_with_groups_but_no_values() {
 
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_gauge",
-                description: "Test grouped gauge",
-                stat_type: Gauge,
-                values: vec![],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_gauge",
+            description: "Test grouped gauge",
+            stat_type: Gauge,
+            values: vec![],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -251,19 +278,16 @@ fn request_for_single_counter_with_groups_and_one_value() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value one".to_string(), "100".to_string()],
-                        value: 1f64,
-                    },
-                ], // LCOV_EXCL_LINE Kcov bug?
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec!["value one".to_string(), "100".to_string()],
+                bucket_index: None,
+                value: 1f64,
+            }], // LCOV_EXCL_LINE Kcov bug?
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -284,19 +308,16 @@ fn request_for_single_gauge_with_groups_and_one_value() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_gauge",
-                description: "Test grouped gauge",
-                stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value two".to_string(), "200".to_string()],
-                        value: 2f64,
-                    },
-                ],
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_gauge",
+            description: "Test grouped gauge",
+            stat_type: Gauge,
+            values: vec![ExpectedStatSnapshotValue {
+                group_values: vec!["value two".to_string(), "200".to_string()],
+                bucket_index: None,
+                value: 2f64,
+            }],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -326,23 +347,235 @@ fn request_for_single_counter_with_groups_and_two_values() {
     let stats = logger.get_stats();
     check_expected_stat_snaphots(
         &stats,
-        &vec![
-            ExpectedStatSnapshot {
-                name: "test_grouped_counter",
-                description: "Test grouped counter",
-                stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value one".to_string(), "100".to_string()],
-                        value: 1f64,
-                    },
-                    ExpectedStatSnapshotValue {
-                        group_values: vec!["value two".to_string(), "200".to_string()],
-                        value: 2f64,
-                    },
-                ], // LCOV_EXCL_LINE Kcov bug?
-            },
-        ],
+        &vec![ExpectedStatSnapshot {
+            name: "test_grouped_counter",
+            description: "Test grouped counter",
+            stat_type: Counter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["value one".to_string(), "100".to_string()],
+                    bucket_index: None,
+                    value: 1f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["value two".to_string(), "200".to_string()],
+                    bucket_index: None,
+                    value: 2f64,
+                },
+            ], // LCOV_EXCL_LINE Kcov bug?
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_freq() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+    let stats = logger.get_stats();
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_freq",
+            description: "Test bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_freq_one_value() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+
+    xlog!(logger, BucketCounterLog { bucket_value: 1.5 });
+
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(
+            BucketMethod::Freq,
+            "bucket",
+            vec![1f64, 2f64, 3f64]
+        ))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_freq",
+            description: "Test bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 1f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_cumul_freq() {
+    static STATS: StatDefinitions = &[&test_bucket_counter_cumul_freq];
+    let (logger, _) = create_logger_buffer(STATS);
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(
+            BucketMethod::CumulFreq,
+            "bucket",
+            vec![1.5, 2.5, 3.5]
+        ))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_bucket_counter_cumul_freq",
+            description: "Test cumulative bucket counter",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(2),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: Some(3),
+                    value: 0f64,
+                },
+            ],
+        }],
+    ); // LCOV_EXCL_LINE Kcov bug?
+}
+
+#[test]
+fn request_for_bucket_counter_with_groups_and_two_values() {
+    static STATS: StatDefinitions = &[&test_group_bucket_counter];
+    let (logger, _) = create_logger_buffer(STATS);
+
+    xlog!(
+        logger,
+        GroupBucketCounterLog {
+            delta: 3,
+            group1: "one".to_string(),
+            group2: "two".to_string(),
+            bucket_value: 7.4
+        } // LCOV_EXCL_LINE Kcov bug?
+    );
+    xlog!(
+        logger,
+        GroupBucketCounterLog {
+            delta: 4,
+            group1: "three".to_string(),
+            group2: "four".to_string(),
+            bucket_value: -20f32
+        } // LCOV_EXCL_LINE Kcov bug?
+    );
+
+    let stats = logger.get_stats();
+
+    assert_eq!(
+        stats[0].definition.buckets(),
+        Some(Buckets::new(
+            BucketMethod::CumulFreq,
+            "bucket",
+            vec![-1.5f64, 0f64]
+        ))
+    );
+
+    check_expected_stat_snaphots(
+        &stats,
+        &vec![ExpectedStatSnapshot {
+            name: "test_group_bucket_counter",
+            description: "Test cumulative bucket counter with groups",
+            stat_type: BucketCounter,
+            values: vec![
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(), "two".to_string()],
+                    bucket_index: Some(0),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(), "two".to_string()],
+                    bucket_index: Some(1),
+                    value: 0f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["one".to_string(), "two".to_string()],
+                    bucket_index: Some(2),
+                    value: 3f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(), "four".to_string()],
+                    bucket_index: Some(0),
+                    value: 4f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(), "four".to_string()],
+                    bucket_index: Some(1),
+                    value: 4f64,
+                },
+                ExpectedStatSnapshotValue {
+                    group_values: vec!["three".to_string(), "four".to_string()],
+                    bucket_index: Some(2),
+                    value: 4f64,
+                },
+            ],
+        }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
@@ -395,23 +628,21 @@ fn request_for_many_metrics() {
                 name: "test_counter",
                 description: "Test counter",
                 stat_type: Counter,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 1f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 1f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
                 description: "Test gauge",
                 stat_type: Gauge,
-                values: vec![
-                    ExpectedStatSnapshotValue {
-                        group_values: vec![],
-                        value: 2f64,
-                    },
-                ],
+                values: vec![ExpectedStatSnapshotValue {
+                    group_values: vec![],
+                    bucket_index: None,
+                    value: 2f64,
+                }],
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_counter",
@@ -420,10 +651,12 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value one".to_string(), "100".to_string()],
+                        bucket_index: None,
                         value: 3f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value two".to_string(), "200".to_string()],
+                        bucket_index: None,
                         value: 4f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
@@ -435,13 +668,96 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value three".to_string(), "300".to_string()],
+                        bucket_index: None,
                         value: 5f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value four".to_string(), "400".to_string()],
+                        bucket_index: None,
                         value: 6f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_freq",
+                description: "Test bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_cumul_freq",
+                description: "Test cumulative bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
+            },
+            ExpectedStatSnapshot {
+                name: "test_bucket_counter_cumul_freq",
+                description: "Test cumulative bucket counter",
+                stat_type: BucketCounter,
+                values: vec![
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(0),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(1),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                    ExpectedStatSnapshotValue {
+                        group_values: vec![],
+                        bucket_index: Some(2),
+                        value: 0f64,
+                    },
+                ],
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -29,13 +29,13 @@ define_stats! {
             BucketCounter,
             "Test cumulative bucket counter",
             [],
-            (CumulFreq, "bucket", [1.5, 2.5, 3.5])
+            (CumulFreq, "bucket", [10, 20, 30])
         ),
         test_group_bucket_counter(
             BucketCounter,
             "Test cumulative bucket counter with groups",
             ["group1", "group2"],
-            (CumulFreq, "bucket", [-1.5, 0])
+            (CumulFreq, "bucket", [-8, 0])
         )
     }
 }
@@ -129,9 +129,10 @@ fn request_for_single_counter() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 0f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -150,9 +151,10 @@ fn request_for_single_gauge() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec![],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 0f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -172,9 +174,10 @@ fn request_for_multiple_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 0f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -182,9 +185,10 @@ fn request_for_multiple_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 0f64,
                 }],
+                buckets: None,
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -209,9 +213,10 @@ fn request_for_updated_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -219,9 +224,10 @@ fn request_for_updated_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 }],
+                buckets: None,
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?
@@ -240,6 +246,7 @@ fn request_for_single_counter_with_groups_but_no_values() {
             description: "Test grouped counter",
             stat_type: Counter,
             values: vec![],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -257,6 +264,7 @@ fn request_for_single_gauge_with_groups_but_no_values() {
             description: "Test grouped gauge",
             stat_type: Gauge,
             values: vec![],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -284,9 +292,10 @@ fn request_for_single_counter_with_groups_and_one_value() {
             stat_type: Counter,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value one".to_string(), "100".to_string()],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 1f64,
-            }], // LCOV_EXCL_LINE Kcov bug?
+            }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -314,9 +323,10 @@ fn request_for_single_gauge_with_groups_and_one_value() {
             stat_type: Gauge,
             values: vec![ExpectedStatSnapshotValue {
                 group_values: vec!["value two".to_string(), "200".to_string()],
-                bucket_index: None,
+                bucket_limit: None,
                 value: 2f64,
             }],
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -354,15 +364,16 @@ fn request_for_single_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value one".to_string(), "100".to_string()],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["value two".to_string(), "200".to_string()],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 },
             ], // LCOV_EXCL_LINE Kcov bug?
+            buckets: None,
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -382,25 +393,30 @@ fn request_for_bucket_counter_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(1)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(2)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(3)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::Freq,
+                "bucket",
+                &vec![1, 2, 3],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -414,15 +430,6 @@ fn request_for_bucket_counter_freq_one_value() {
 
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::Freq,
-            "bucket",
-            vec![1f64, 2f64, 3f64]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -432,25 +439,30 @@ fn request_for_bucket_counter_freq_one_value() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(1)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(2)),
                     value: 1f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(3)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::Freq,
+                "bucket",
+                &vec![1, 2, 3],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -461,15 +473,6 @@ fn request_for_bucket_counter_cumul_freq() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::CumulFreq,
-            "bucket",
-            vec![1.5, 2.5, 3.5]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -479,25 +482,30 @@ fn request_for_bucket_counter_cumul_freq() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(10)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(20)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Num(30)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: Some(3),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 0f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::CumulFreq,
+                "bucket",
+                &vec![10, 20, 30],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -528,15 +536,6 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
 
     let stats = logger.get_stats();
 
-    assert_eq!(
-        stats[0].definition.buckets(),
-        Some(Buckets::new(
-            BucketMethod::CumulFreq,
-            "bucket",
-            vec![-1.5f64, 0f64]
-        ))
-    );
-
     check_expected_stat_snaphots(
         &stats,
         &vec![ExpectedStatSnapshot {
@@ -546,35 +545,40 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
             values: vec![
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(-8)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(0)),
                     value: 0f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["one".to_string(), "two".to_string()],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 3f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(0),
+                    bucket_limit: Some(BucketLimit::Num(-8)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(1),
+                    bucket_limit: Some(BucketLimit::Num(0)),
                     value: 4f64,
                 },
                 ExpectedStatSnapshotValue {
                     group_values: vec!["three".to_string(), "four".to_string()],
-                    bucket_index: Some(2),
+                    bucket_limit: Some(BucketLimit::Unbounded),
                     value: 4f64,
                 },
             ],
+            buckets: Some(Buckets::new(
+                BucketMethod::CumulFreq,
+                "bucket",
+                &vec![-8, 0],
+            )),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -630,9 +634,10 @@ fn request_for_many_metrics() {
                 stat_type: Counter,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 1f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_gauge",
@@ -640,9 +645,10 @@ fn request_for_many_metrics() {
                 stat_type: Gauge,
                 values: vec![ExpectedStatSnapshotValue {
                     group_values: vec![],
-                    bucket_index: None,
+                    bucket_limit: None,
                     value: 2f64,
                 }],
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_counter",
@@ -651,15 +657,16 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value one".to_string(), "100".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 3f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value two".to_string(), "200".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 4f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_grouped_gauge",
@@ -668,15 +675,16 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value three".to_string(), "300".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 5f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec!["value four".to_string(), "400".to_string()],
-                        bucket_index: None,
+                        bucket_limit: None,
                         value: 6f64,
                     },
                 ], // LCOV_EXCL_LINE Kcov bug?
+                buckets: None,
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_freq",
@@ -685,25 +693,30 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(0),
+                        bucket_limit: Some(BucketLimit::Num(1)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(1),
+                        bucket_limit: Some(BucketLimit::Num(2)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Num(3)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Unbounded),
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::Freq,
+                    "bucket",
+                    &vec![1, 2, 3],
+                )),
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_cumul_freq",
@@ -712,25 +725,30 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(0),
+                        bucket_limit: Some(BucketLimit::Num(10)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(1),
+                        bucket_limit: Some(BucketLimit::Num(20)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Num(30)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Unbounded),
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::CumulFreq,
+                    "bucket",
+                    &vec![10, 20, 30],
+                )),
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_cumul_freq",
@@ -739,25 +757,30 @@ fn request_for_many_metrics() {
                 values: vec![
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(0),
+                        bucket_limit: Some(BucketLimit::Num(10)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(1),
+                        bucket_limit: Some(BucketLimit::Num(20)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Num(30)),
                         value: 0f64,
                     },
                     ExpectedStatSnapshotValue {
                         group_values: vec![],
-                        bucket_index: Some(2),
+                        bucket_limit: Some(BucketLimit::Unbounded),
                         value: 0f64,
                     },
                 ],
+                buckets: Some(Buckets::new(
+                    BucketMethod::CumulFreq,
+                    "bucket",
+                    &vec![10, 20, 30],
+                )),
             },
         ], // LCOV_EXCL_LINE Kcov bug?
     ); // LCOV_EXCL_LINE Kcov bug?


### PR DESCRIPTION
This is a copy of https://github.com/slog-rs/extlog/pull/6 with a tidied up git history.

* The define_stats! macro is updated to accept the BucketCounter stat type and to take the additional parameters that it requires: An enum value that determines how values should be sorted into buckets, a label name describing what the buckets measure, and a list of i64s defining the bucket boundaries. This is a backwards compatible change.
* The StatSnapshot struct is updated to contain information about the bucketed values. This is a breaking change.
* The StatLogData struct is unchanged, and treats the buckets as additional tags, with the tag name given by the bucket label name.