### PR TITLE
Add fixed groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 ### Added
+- Add the `FixedGroups` attribute to `StatTrigger`, allowing for a compile-time constant value on
+a metric.
 
 ## [5.0.0]
 ### Changed

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -346,6 +346,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         })
         .collect::<Vec<_>>();
 
+    // Build up the return value for the `stat_list` method.
     let stat_ids = triggers
         .iter()
         .map(|t| {
@@ -361,6 +362,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         })
         .collect::<Vec<_>>();
 
+    // Build up the input match statements value for the `condition` method.
     let stat_ids_cond = triggers
         .iter()
         .map(|t| {
@@ -370,20 +372,24 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .unzip();
             let id = t.id.to_string();
-            // The horrific chicanery here is because match guards can;t use mutable borrows, so
+            // The horrific chicanery here is because match guards can't use mutable borrows, so
             // `any` and `find` and such methods can't be used.
             quote! {
                 #id if (true #(&& stat_id.fixed_tags.iter().filter(|tag| tag.0 == #keys && tag.1 == #vals).count() != 0) *)
             }
         })
         .collect::<Vec<_>>();
+
+    // Build up the return values for those match statements.
     let stat_conds = triggers
         .iter()
         .map(|ref t| &t.condition_body)
         .collect::<Vec<_>>();
 
+    // Build up the input match statements value for the `change` method.
     let stat_ids_change = stat_ids_cond.clone();
-    // Write out any stats triggering code.
+
+    // Build up the return values for those match statements.
     let stat_changes = triggers
         .iter()
         .map(|t| {

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -86,7 +86,7 @@
 //! extern crate erased_serde;
 //!
 //! use slog_extlog::ExtLoggable;
-//! use slog_extlog::stats::{StatDefinition, StatDefinitionTagged};
+//! use slog_extlog::stats::StatDefinition;
 //!
 //! #[derive(Clone, Serialize, SlogValue)]
 //! enum FooRspCode {
@@ -356,7 +356,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
                 .unzip();
             let id = &t.id;
             quote! {
-               StatDefinitionTagged { defn: &#id, fixed_tags: &[#( (#keys, #vals) ),*] }
+               ::slog_extlog::stats::StatDefinitionTagged { defn: &#id, fixed_tags: &[#( (#keys, #vals) ),*] }
             }
         })
         .collect::<Vec<_>>();
@@ -454,14 +454,14 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
     // Create a new identifier for the list of stats, so we can make the list globally static.
     let stat_ids_name = syn::Ident::from(format!("STATS_LIST_{}", name).to_uppercase());
 
-    let res = quote! {
+    quote! {
         static #stat_ids_name: &'static [slog_extlog::stats::StatDefinitionTagged] = &[#(#stat_ids),*];
         impl<#(#lifetimes,)* #(#tys),*> ::slog_extlog::stats::StatTrigger
             for #name<#(#lifetimes,)* #(#tys_2),*>
         #(where #tys_3: #(#bounds + )* ::slog::Value),*{
 
             fn stat_list(
-                &self) -> &'static[StatDefinitionTagged] {
+                &self) -> &'static[::slog_extlog::stats::StatDefinitionTagged] {
                 #stat_ids_name
             }
 
@@ -510,9 +510,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
                 }
             }
         }
-    };
-    // dbg!(&res);
-    res
+    }
 }
 
 fn impl_loggable(ast: &syn::DeriveInput) -> quote::Tokens {

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -246,7 +246,8 @@ pub fn slog_value(input: TokenStream) -> TokenStream {
 ///
 /// Do not call this function directly.  Use `#[derive]` instead.
 #[proc_macro_derive(
-    ExtLoggable, attributes(LogDetails, FixedFields, StatTrigger, StatGroup, BucketBy)
+    ExtLoggable,
+    attributes(LogDetails, FixedFields, StatTrigger, StatGroup, BucketBy)
 )]
 pub fn loggable(input: TokenStream) -> TokenStream {
     // Construct a string representation of the type definition
@@ -335,7 +336,8 @@ fn get_types_bounds(
 
 fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
     // Get stat triggering details.
-    let triggers = ast.attrs
+    let triggers = ast
+        .attrs
         .iter()
         .filter(|a| a.name() == "StatTrigger")
         .map(|ref val| match val.value {
@@ -380,14 +382,11 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
         .collect::<Vec<_>>();
 
     // Build up the tag (group) info for each stat.
-    let mut stats_groups = quote!{};
+    let mut stats_groups = quote! {};
     for t in &triggers {
         let id = &t.id.to_string();
         let fixed_group_names = t.fixed_groups.keys().cloned().collect::<Vec<_>>();
-        let fixed_group_vals = t.fixed_groups
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
+        let fixed_group_vals = t.fixed_groups.values().cloned().collect::<Vec<_>>();
         let dyn_groups = t.field_groups.clone();
         let dyn_groups_str = dyn_groups
             .clone()
@@ -404,7 +403,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
     }
 
     // Build up the bucket info for each stat.
-    let mut stats_buckets = quote!{};
+    let mut stats_buckets = quote! {};
     for t in &triggers {
         let id = &t.id.to_string();
         let bucket = t.bucket_by.clone();
@@ -419,7 +418,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
     let tag_name_ident = if !triggers.is_empty() {
         quote! { tag_name }
     } else {
-        quote!{ _tag_name }
+        quote! { _tag_name }
     };
 
     let name = &ast.ident;
@@ -497,7 +496,8 @@ fn impl_loggable(ast: &syn::DeriveInput) -> quote::Tokens {
     let tys_3 = tys.clone();
 
     // Get the log details from the attribute.
-    let vals = ast.attrs
+    let vals = ast
+        .attrs
         .iter()
         .filter(|a| a.name() == "LogDetails")
         .collect::<Vec<_>>();
@@ -510,7 +510,8 @@ fn impl_loggable(ast: &syn::DeriveInput) -> quote::Tokens {
     };
 
     // Get the fixed fields from the attribute.
-    let fields = ast.attrs
+    let fields = ast
+        .attrs
         .iter()
         .filter(|a| a.name() == "FixedFields")
         .flat_map(|ref val| match val.value {

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -46,14 +46,24 @@
 //!   - `Condition` (optional) - A condition, absed on the log fields, for this stat to be changed.
 //!      if not set, the stat is changed on every log.  The value of this parameter is an
 //!        expression that returns a Boolean, and can use `self` for the current log object.
-//!   - `Value` or `ValueFrom` - - The value to increment/decrement/set.  One and only one
+//!   - `Value` or `ValueFrom` - The value to increment/decrement/set.  One and only one
 //!   of these must be provided.  `Value` for a fixed number, `ValueFrom` for an arbitrary
 //!   expression to find the value that may return self.
+//!   - `FixedGroups (optional)` - A comma-separated list of fixed tags to add to this statistic
+//!   for this trigger - see below.
 //!
 //! ### Grouped (tagged) statistics)
-//! Some statistics may be grouped with *tags*.  To specify which field within the triggering log
-//! should be used for the group value, add a `#[StatGroup(StatName = "<name>")] attribute, where
-//! `<id>` is the relevant statistic name.
+//! Some statistics may be grouped with *tags*.  Tags can be defined in two ways.
+//!
+//!  - To add one or more *fixed* groups on a given statistic update, add an attribute to the
+//!    `StatTrigger` of the form:  `FixedGroups = "<name>=<value>,<name2>=<value2>,...".
+//!    The names must be the names of the tags within the statistic definition.
+//!  - To add a *dynamic* tag, you can take the value from a single field in the log. To specify
+//!    which field within the triggering log should be used for the group value, add a
+//!    `#[StatGroup(StatName = "<name>")] attribute on the relevant field within the log, where
+//!    `<name>` is the relevant statistic name.
+//!    The name of the group within the statistic definition *must* be the name of the field
+//!    in the log structure.
 //!
 //! **WARNING** - be careful with tagging where there can be large numbers of values - each seen
 //! value for the tag generates a new statistic, which is tracked forever once it is seen.
@@ -174,6 +184,7 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use slog::Level;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 enum StatTriggerAction {
@@ -208,7 +219,8 @@ struct StatTriggerData {
     condition_body: syn::Expr,
     action: StatTriggerAction,
     val: StatTriggerValue,
-    group_by: Vec<syn::Ident>,
+    fixed_groups: HashMap<String, String>,
+    field_groups: Vec<syn::Ident>,
     bucket_by: Option<syn::Ident>,
 }
 
@@ -371,15 +383,21 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> quote::Tokens {
     let mut stats_groups = quote!{};
     for t in &triggers {
         let id = &t.id.to_string();
-        let groups = t.group_by.clone();
-        let groups_str = groups
+        let fixed_group_names = t.fixed_groups.keys().cloned().collect::<Vec<_>>();
+        let fixed_group_vals = t.fixed_groups
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let dyn_groups = t.field_groups.clone();
+        let dyn_groups_str = dyn_groups
             .clone()
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
         stats_groups = quote! { #stats_groups
             #id => { match tag_name {
-              #(#groups_str => self.#groups.to_string(),)*
+              #(#dyn_groups_str => self.#dyn_groups.to_string(),)*
+              #(#fixed_group_names => #fixed_group_vals.to_string(),)*
                 _ => "".to_string() }
             },
         }
@@ -665,6 +683,7 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
     let mut cond = None;
     let mut action = None;
     let mut value = None;
+    let mut fixed_groups = HashMap::new();
 
     for attr in attr_val {
         let (name, val) = match *attr {
@@ -679,7 +698,7 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
 
         match name {
             "StatName" => {
-                id = Some(syn::parse_ident(val).expect("Could not parse condition in StatTrigger"))
+                id = Some(syn::parse_ident(val).expect("Could not parse name in StatTrigger"))
             }
             "Condition" => {
                 cond = Some(syn::parse_expr(val).expect("Could not parse condition in StatTrigger"))
@@ -699,12 +718,22 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
                     syn::parse_expr(val).expect("Invalid ValueFrom in StatTrigger"),
                 ))
             }
+            "FixedGroups" => {
+                // Split the value
+                let groups = val.split(",");
+                for group in groups {
+                    let mut split = group.splitn(2, "=");
+                    let group_name = split.next().expect("Invalid format for FixedGroups");
+                    let group_val = split.next().expect("Invalid format for FixedGroups");
+                    fixed_groups.insert(group_name.to_string(), group_val.to_string());
+                }
+            }
             _ => panic!("Unrecognised key in StatTrigger attribute"),
         }
     }
 
     let id = id.expect("StatTrigger missing value for StatName");
-    let groups = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
+    let field_groups = if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = *body {
         fields
             .iter()
             .filter(|f| {
@@ -745,7 +774,8 @@ fn parse_stat_trigger(attr_val: &[syn::NestedMetaItem], body: &syn::Body) -> Sta
         condition_body: cond.unwrap_or_else(|| syn::parse_expr("true").unwrap()),
         action: action.expect("StatTrigger missing value for Action"),
         val: value.expect("StatTrigger missing value for Value or ValueFrom"),
-        group_by: groups,
+        fixed_groups,
+        field_groups,
         bucket_by: bucket_field,
     }
 }

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -67,7 +67,11 @@ fn test_derived_structs() {
     }
 
     #[derive(Debug, Clone, Serialize, ExtLoggable)]
-    #[LogDetails(Id = "456", Text = "Received a foo response from server", Level = "Info")]
+    #[LogDetails(
+        Id = "456",
+        Text = "Received a foo response from server",
+        Level = "Info"
+    )]
     struct FooRspRcvd(FooRspType, &'static str);
     // LCOV_EXCL_STOP
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,11 +175,8 @@ pub mod slog_test;
 /// Any generic parameters in `ExtLoggable` objects must have this as a trait bound.
 pub trait SlogValueDerivable: std::fmt::Debug + Clone + serde::Serialize + Send + 'static {}
 
-impl<T> SlogValueDerivable for T
-where
-    T: std::fmt::Debug + Clone + serde::Serialize + Send + 'static,
-{
-}
+impl<T> SlogValueDerivable for T where T: std::fmt::Debug + Clone + serde::Serialize + Send + 'static
+{}
 
 /// The default logger type.
 pub type DefaultLogger = stats::StatisticsLogger<stats::DefaultStatisticsLogFormatter>;

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -51,6 +51,7 @@
 //! For verifying statistics, the `create_logger_buffer` and `check_expected_stats` methods
 //! are useful for creating a `slog_extlog::StatisticsLogger` and then verifying that statistics
 //! are generated as expected.
+#![allow(clippy::float_cmp)]
 pub extern crate erased_serde;
 pub extern crate iobuffer;
 pub extern crate serde_json;

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -231,7 +231,8 @@ pub fn check_expected_stat_snaphots(
         match found_stat.values {
             StatSnapshotValues::Counter(ref vals) | StatSnapshotValues::Gauge(ref vals) => {
                 for value in &stat.values {
-                    let found_value = vals.iter()
+                    let found_value = vals
+                        .iter()
                         .find(|val| val.group_values == value.group_values);
 
                     assert!(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -287,17 +287,16 @@ impl Buckets {
     /// return a vector containing the indices of the buckets that should be updated
     pub fn assign_buckets(&self, value: f64) -> Vec<usize> {
         match self.method {
-            BucketMethod::CumulFreq => {
-                self.limits
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, limit)| match limit {
-                        BucketLimit::Num(b) => (value <= *b as f64),
-                        BucketLimit::Unbounded => true,
-                    })
-                    .map(|(i, _)| i)
-                    .collect()
-            }
+            BucketMethod::CumulFreq => self
+                .limits
+                .iter()
+                .enumerate()
+                .filter(|(_, limit)| match limit {
+                    BucketLimit::Num(b) => (value <= *b as f64),
+                    BucketLimit::Unbounded => true,
+                })
+                .map(|(i, _)| i)
+                .collect(),
             BucketMethod::Freq => {
                 let mut min_limit_index = self.limits.len() - 1;
                 for (i, limit) in self.limits.iter().enumerate() {
@@ -575,7 +574,7 @@ impl<T: StatisticsLogFormatter> StatsConfigBuilder<T> {
 
 // A default `StatsDefinition` with no statistics in it.
 // Deprecated since 4.0 - just use an empty vector.
-define_stats!{ EMPTY_STATS = {} }
+define_stats! { EMPTY_STATS = {} }
 
 impl<F> Default for StatsConfig<F>
 where
@@ -936,7 +935,8 @@ impl BucketCounterData {
         buckets_to_update: &[usize],
     ) {
         let change = trigger.change(defn).expect("Bad log definition");
-        let tag_values = defn.group_by()
+        let tag_values = defn
+            .group_by()
             .iter()
             .map(|n| trigger.tag_value(defn, n))
             .collect::<Vec<String>>()
@@ -1137,7 +1137,8 @@ impl Stat {
 
     fn update_grouped(&self, defn: &StatDefinition, trigger: &StatTrigger) {
         let change = trigger.change(defn).expect("Bad log definition");
-        let tag_values = self.defn
+        let tag_values = self
+            .defn
             .group_by()
             .iter()
             .map(|n| trigger.tag_value(defn, n))

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -196,23 +196,31 @@ macro_rules! define_stats {
     };
 }
 
-/// A trait indicating that this statistic can be used to trigger a statistics change.
+/// A stat definition, possibly filtered with some specific tag values.
+pub struct StatDefinitionTagged {
+    /// The statistic definition
+    pub defn: &'static (StatDefinition + Sync),
+    /// THe fixed tag values.  The keys *must* match keys in `defn`.
+    pub fixed_tags: &'static [(&'static str, &'static str)],
+}
+
+/// A trait indicating that this log can be used to trigger a statistics change.
 pub trait StatTrigger {
     /// The list of stats that this trigger applies to.
-    fn stat_list(&self) -> &'static [&'static (StatDefinition + Sync)];
+    fn stat_list(&self) -> &[StatDefinitionTagged];
     /// The condition that must be satisfied for this stat to change
-    fn condition(&self, _stat_id: &StatDefinition) -> bool {
+    fn condition(&self, _stat_id: &StatDefinitionTagged) -> bool {
         false
     }
     /// Get the associated tag value for this log.
     /// The value must be convertable to a string so it can be stored internally.
-    fn tag_value(&self, stat_id: &StatDefinition, _tag_name: &'static str) -> String;
+    fn tag_value(&self, stat_id: &StatDefinitionTagged, _tag_name: &'static str) -> String;
     /// The details of the change to make for this stat, if `condition` returned true.
-    fn change(&self, _stat_id: &StatDefinition) -> Option<ChangeType> {
+    fn change(&self, _stat_id: &StatDefinitionTagged) -> Option<ChangeType> {
         None
     }
     /// The value to be used to sort the statistic into the correct bucket(s).
-    fn bucket_value(&self, _stat_id: &StatDefinition) -> Option<f64> {
+    fn bucket_value(&self, _stat_id: &StatDefinitionTagged) -> Option<f64> {
         None
     }
 }
@@ -407,16 +415,17 @@ where
     /// This checks for any configured stats that are triggered by this log, and
     /// updates their value appropriately.
     fn update_stats(&self, log: &StatTrigger) {
-        for defn in log.stat_list() {
-            if log.condition(*defn) {
-                let stat = &self.stats.get(defn.name()).unwrap_or_else(|| {
+        for stat_def in log.stat_list() {
+            if log.condition(stat_def) {
+                let stat = &self.stats.get(stat_def.defn.name()).unwrap_or_else(|| {
                     panic!(
                         "No statistic found with name {}, did you try writing a log through a
                          logger which wasn't initialized with your stats definitions?",
-                        defn.name()
+                        stat_def.defn.name()
                     )
                 });
-                stat.update(*defn, log)
+
+                stat.update(stat_def, log)
             }
         }
     }
@@ -853,7 +862,7 @@ impl StatTypeData {
     }
 
     /// Update the stat values
-    fn update(&self, defn: &StatDefinition, trigger: &StatTrigger) {
+    fn update(&self, defn: &StatDefinitionTagged, trigger: &StatTrigger) {
         if let StatTypeData::BucketCounter(ref bucket_counter_data) = self {
             bucket_counter_data.update(defn, trigger);
         }
@@ -909,7 +918,7 @@ impl BucketCounterData {
     }
 
     /// Update the stat values.
-    fn update(&self, defn: &StatDefinition, trigger: &StatTrigger) {
+    fn update(&self, defn: &StatDefinitionTagged, trigger: &StatTrigger) {
         // Update the bucketed values.
         let bucket_value = trigger.bucket_value(defn).expect("Bad log definition");
         let buckets_to_update = self.buckets.assign_buckets(bucket_value);
@@ -930,12 +939,13 @@ impl BucketCounterData {
     /// Update the grouped stat values.
     fn update_grouped(
         &self,
-        defn: &StatDefinition,
+        defn: &StatDefinitionTagged,
         trigger: &StatTrigger,
         buckets_to_update: &[usize],
     ) {
         let change = trigger.change(defn).expect("Bad log definition");
         let tag_values = defn
+            .defn
             .group_by()
             .iter()
             .map(|n| trigger.tag_value(defn, n))
@@ -1121,7 +1131,7 @@ impl Stat {
     }
 
     /// Update the stat's value(s) according to the given `StatTrigger` and `StatDefinition`.
-    fn update(&self, defn: &StatDefinition, trigger: &StatTrigger) {
+    fn update(&self, defn: &StatDefinitionTagged, trigger: &StatTrigger) {
         // update the stat value
         self.value
             .update(&trigger.change(defn).expect("Bad log definition"));
@@ -1135,8 +1145,9 @@ impl Stat {
         self.stat_type_data.update(defn, trigger);
     }
 
-    fn update_grouped(&self, defn: &StatDefinition, trigger: &StatTrigger) {
+    fn update_grouped(&self, defn: &StatDefinitionTagged, trigger: &StatTrigger) {
         let change = trigger.change(defn).expect("Bad log definition");
+
         let tag_values = self
             .defn
             .group_by()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -309,7 +309,7 @@ impl Buckets {
                 let mut min_limit_index = self.limits.len() - 1;
                 for (i, limit) in self.limits.iter().enumerate() {
                     if let BucketLimit::Num(b) = limit {
-                        if value <= *b as f64 && limit <= &self.limits[min_limit_index] {
+                        if value <= *b as f64 && *limit <= self.limits[min_limit_index] {
                             min_limit_index = i
                         }
                     }
@@ -385,16 +385,25 @@ pub struct StatsTracker<T: StatisticsLogFormatter> {
 }
 // LCOV_EXCL_STOP
 
+impl<T> Default for StatsTracker<T>
+where
+    T: StatisticsLogFormatter,
+{
+    fn default() -> Self {
+        StatsTracker {
+            stats: HashMap::new(),
+            stat_formatter: PhantomData,
+        }
+    }
+}
+
 impl<T> StatsTracker<T>
 where
     T: StatisticsLogFormatter,
 {
     /// Create a new tracker with the given formatter.
     pub fn new() -> Self {
-        StatsTracker {
-            stats: HashMap::new(),
-            stat_formatter: PhantomData,
-        } // LCOV_EXCL_LINE Kcov bug?
+        Default::default()
     }
 
     /// Add a new statistic to this tracker.
@@ -537,6 +546,17 @@ where
 /// ```
 pub struct StatsConfigBuilder<T: StatisticsLogFormatter> {
     cfg: StatsConfig<T>,
+}
+
+impl<T> Default for StatsConfigBuilder<T>
+where
+    T: StatisticsLogFormatter,
+{
+    fn default() -> Self {
+        StatsConfigBuilder {
+            cfg: Default::default(),
+        }
+    }
 }
 
 impl<T: StatisticsLogFormatter> StatsConfigBuilder<T> {

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -147,7 +147,13 @@ struct SixthExternalLog {
     StatName = "test_double_grouped",
     Action = "Incr",
     Value = "1",
-    FixedGroups = "name=foobar"
+    FixedGroups = "name=foo"
+)]
+#[StatTrigger(
+    StatName = "test_double_grouped",
+    Action = "Incr",
+    Value = "1",
+    FixedGroups = "name=bar"
 )]
 struct FixedExternalLog {
     #[StatGroup(StatName = "test_double_grouped")]
@@ -373,20 +379,32 @@ fn basic_extloggable_fixed_group() {
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
     let logs = get_stat_logs("test_double_grouped", &mut data);
-    assert_eq!(logs.len(), 2);
+    assert_eq!(logs.len(), 4);
 
     check_expected_stats(
         &logs,
         vec![
             ExpectedStat {
                 stat_name: "test_double_grouped",
-                tag: Some("name=foobar,error=23"),
+                tag: Some("name=foo,error=23"),
                 value: 2f64,
                 metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
-                tag: Some("name=foobar,error=42"),
+                tag: Some("name=foo,error=42"),
+                value: 1f64,
+                metric_type: "counter",
+            },
+            ExpectedStat {
+                stat_name: "test_double_grouped",
+                tag: Some("name=bar,error=23"),
+                value: 2f64,
+                metric_type: "counter",
+            },
+            ExpectedStat {
+                stat_name: "test_double_grouped",
+                tag: Some("name=bar,error=42"),
                 value: 1f64,
                 metric_type: "counter",
             },

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -146,7 +146,7 @@ struct SixthExternalLog {
 #[StatTrigger(
     StatName = "test_double_grouped",
     Action = "Incr",
-    Value = "1",
+    Value = "3",
     FixedGroups = "name=foo"
 )]
 #[StatTrigger(
@@ -387,13 +387,13 @@ fn basic_extloggable_fixed_group() {
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=23"),
-                value: 2f64,
+                value: 6f64,
                 metric_type: "counter",
             },
             ExpectedStat {
                 stat_name: "test_double_grouped",
                 tag: Some("name=foo,error=42"),
-                value: 1f64,
+                value: 3f64,
                 metric_type: "counter",
             },
             ExpectedStat {

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -39,7 +39,10 @@ define_stats! {
 #[StatTrigger(StatName = "test_counter", Action = "Incr", Value = "1")]
 #[StatTrigger(StatName = "test_second_counter", Action = "Incr", Value = "1")]
 #[StatTrigger(
-    StatName = "test_gauge", Condition = "self.bytes < 200", Action = "Incr", Value = "1"
+    StatName = "test_gauge",
+    Condition = "self.bytes < 200",
+    Action = "Incr",
+    Value = "1"
 )]
 #[StatTrigger(
     StatName = "test_second_gauge",
@@ -56,7 +59,10 @@ struct ExternalLog {
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "2", Text = "Some floating point number", Level = "Error")]
 #[StatTrigger(
-    StatName = "test_gauge", Condition = "self.floating > 1.0", Action = "Decr", Value = "1"
+    StatName = "test_gauge",
+    Condition = "self.floating > 1.0",
+    Action = "Decr",
+    Value = "1"
 )]
 struct SecondExternalLog {
     floating: f32,
@@ -65,7 +71,10 @@ struct SecondExternalLog {
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "3", Text = "A string of text", Level = "Warning")]
 #[StatTrigger(
-    StatName = "test_foo_count", Condition = "self.name == \"foo\"", Action = "Incr", Value = "1"
+    StatName = "test_foo_count",
+    Condition = "self.name == \"foo\"",
+    Action = "Incr",
+    Value = "1"
 )]
 #[StatTrigger(StatName = "test_grouped_counter", Action = "Incr", Value = "1")]
 struct ThirdExternalLog {
@@ -93,7 +102,11 @@ struct FourthExternalLog {
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "5", Text = "Some floating point number", Level = "Error")]
 #[StatTrigger(StatName = "test_bucket_counter_freq", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_bucket_counter_cumul_freq", Action = "Incr", Value = "1")]
+#[StatTrigger(
+    StatName = "test_bucket_counter_cumul_freq",
+    Action = "Incr",
+    Value = "1"
+)]
 struct FifthExternalLog {
     #[BucketBy(StatName = "test_bucket_counter_freq")]
     #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
@@ -101,9 +114,21 @@ struct FifthExternalLog {
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(Id = "6", Text = "Some floating point number with name and error", Level = "Error")]
-#[StatTrigger(StatName = "test_bucket_counter_grouped_freq", Action = "Incr", Value = "1")]
-#[StatTrigger(StatName = "test_bucket_counter_grouped_cumul_freq", Action = "Incr", Value = "1")]
+#[LogDetails(
+    Id = "6",
+    Text = "Some floating point number with name and error",
+    Level = "Error"
+)]
+#[StatTrigger(
+    StatName = "test_bucket_counter_grouped_freq",
+    Action = "Incr",
+    Value = "1"
+)]
+#[StatTrigger(
+    StatName = "test_bucket_counter_grouped_cumul_freq",
+    Action = "Incr",
+    Value = "1"
+)]
 struct SixthExternalLog {
     #[StatGroup(StatName = "test_bucket_counter_grouped_freq")]
     #[StatGroup(StatName = "test_bucket_counter_grouped_cumul_freq")]
@@ -118,7 +143,12 @@ struct SixthExternalLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "3", Text = "A string of text", Level = "Warning")]
-#[StatTrigger(StatName = "test_double_grouped", Action = "Incr", Value = "1", FixedGroups = "name=foobar")]
+#[StatTrigger(
+    StatName = "test_double_grouped",
+    Action = "Incr",
+    Value = "1",
+    FixedGroups = "name=foobar"
+)]
 struct FixedExternalLog {
     #[StatGroup(StatName = "test_double_grouped")]
     error: u8,
@@ -332,30 +362,13 @@ fn basic_extloggable_grouped_by_string() {
     );
 }
 
-
 #[test]
 fn basic_extloggable_fixed_group() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
-    xlog!(
-        logger,
-        FixedExternalLog {
-            error: 23,
-        }
-    );
-    xlog!(
-        logger,
-        FixedExternalLog {
-            error: 23,
-        }
-    );
-    xlog!(
-        logger,
-        FixedExternalLog {
-            error: 42,
-        }
-    );
-
+    xlog!(logger, FixedExternalLog { error: 23 });
+    xlog!(logger, FixedExternalLog { error: 23 });
+    xlog!(logger, FixedExternalLog { error: 42 });
 
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -57,7 +57,11 @@ struct GaugeUpdateLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "3", Text = "Amount sent", Level = "Info")]
-#[StatTrigger(StatName = "test_grouped_counter", Action = "Incr", ValueFrom = "self.delta")]
+#[StatTrigger(
+    StatName = "test_grouped_counter",
+    Action = "Incr",
+    ValueFrom = "self.delta"
+)]
 struct GroupedCounterUpdateLog {
     delta: i32,
     #[StatGroup(StatName = "test_grouped_counter")]
@@ -68,7 +72,11 @@ struct GroupedCounterUpdateLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(Id = "4", Text = "Amount sent", Level = "Info")]
-#[StatTrigger(StatName = "test_grouped_gauge", Action = "Incr", ValueFrom = "self.delta")]
+#[StatTrigger(
+    StatName = "test_grouped_gauge",
+    Action = "Incr",
+    ValueFrom = "self.delta"
+)]
 struct GroupedGaugeUpdateLog {
     delta: i32,
     #[StatGroup(StatName = "test_grouped_gauge")]
@@ -86,16 +94,32 @@ struct BucketCounterLog {
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(Id = "5", Text = "cumulative test bucket counter stat log", Level = "Info")]
-#[StatTrigger(StatName = "test_bucket_counter_cumul_freq", Action = "Incr", Value = "2")]
+#[LogDetails(
+    Id = "5",
+    Text = "cumulative test bucket counter stat log",
+    Level = "Info"
+)]
+#[StatTrigger(
+    StatName = "test_bucket_counter_cumul_freq",
+    Action = "Incr",
+    Value = "2"
+)]
 struct CumulBucketCounterLog {
     #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
     bucket_value: f32,
 }
 
 #[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(Id = "6", Text = "test grouped bucket counter stat log", Level = "Info")]
-#[StatTrigger(StatName = "test_group_bucket_counter", Action = "Incr", ValueFrom = "self.delta")]
+#[LogDetails(
+    Id = "6",
+    Text = "test grouped bucket counter stat log",
+    Level = "Info"
+)]
+#[StatTrigger(
+    StatName = "test_group_bucket_counter",
+    Action = "Incr",
+    ValueFrom = "self.delta"
+)]
 struct GroupBucketCounterLog {
     delta: i32,
     #[StatGroup(StatName = "test_group_bucket_counter")]
@@ -412,11 +436,7 @@ fn request_for_bucket_counter_freq() {
                     value: 0f64,
                 },
             ],
-            buckets: Some(Buckets::new(
-                BucketMethod::Freq,
-                "bucket",
-                &vec![1, 2, 3],
-            )),
+            buckets: Some(Buckets::new(BucketMethod::Freq, "bucket", &vec![1, 2, 3])),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -458,11 +478,7 @@ fn request_for_bucket_counter_freq_one_value() {
                     value: 0f64,
                 },
             ],
-            buckets: Some(Buckets::new(
-                BucketMethod::Freq,
-                "bucket",
-                &vec![1, 2, 3],
-            )),
+            buckets: Some(Buckets::new(BucketMethod::Freq, "bucket", &vec![1, 2, 3])),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }
@@ -712,11 +728,7 @@ fn request_for_many_metrics() {
                         value: 0f64,
                     },
                 ],
-                buckets: Some(Buckets::new(
-                    BucketMethod::Freq,
-                    "bucket",
-                    &vec![1, 2, 3],
-                )),
+                buckets: Some(Buckets::new(BucketMethod::Freq, "bucket", &vec![1, 2, 3])),
             },
             ExpectedStatSnapshot {
                 name: "test_bucket_counter_cumul_freq",


### PR DESCRIPTION
At the moment, statistic groups can only have their value populated based on a field in the log.  In some cases that isn't ideal - we might want a given triggering log to increment a metric with a fixed, known group value.  

So I've added a `FixedGroups` attribute that makes this possible.

This includes rustfmt changes: the functional changes are all in` slog-extlog-derive/lib.rs` and the test file `stats_extlog.rs`.