### PR TITLE
Fix warning level breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [5.2.1]
+### Changed
 - Ensure that derive log level handling still works with `slog` 2.5.
 
 ## [5.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Ensure that derive log level handling still works with `slog` 2.5.
 
 ## [5.2.0]
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "5.2.0"
+version = "5.2.1"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
 homepage = "https://github.com/slog-rs/extlog"

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-extlog-derive"
-version = "5.2.0"
+version = "5.2.1"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -620,8 +620,16 @@ fn parse_log_details(attr_val: &[syn::NestedMetaItem]) -> (Level, String, u64) {
                         syn::Lit::Str(ref s, _) => {
                             // Level must be a valid slog::Level.  Generate an error if not.
                             Some(
-                                Level::from_str(&s)
-                                    .unwrap_or_else(|_| panic!("Invalid log level provided: {}", s)),
+                                // We handle "Warning" specially - Level::from_str *used* to
+                                // erroneously handle this as it only did prefix matches, but
+                                // now it requires exactly the word "Warn".
+                                if s == "Warning" {
+                                    Level::Warning
+                                } else {
+                                    Level::from_str(&s).unwrap_or_else(|_| {
+                                        panic!("Invalid log level provided: {}", s)
+                                    })
+                                },
                             )
                         }
                         _ => panic!(

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -510,12 +510,7 @@ fn test_extloggable_bucket_counter_freq() {
 #[test]
 fn test_extloggable_bucket_counter_freq_high_value() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
-    xlog!(
-        logger,
-        FifthExternalLog {
-            floating: 10_f32
-        }
-    );
+    xlog!(logger, FifthExternalLog { floating: 10_f32 });
 
     // Wait for the stats logs.
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -584,11 +584,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
                     value: 4f64,
                 },
             ],
-            buckets: Some(Buckets::new(
-                BucketMethod::CumulFreq,
-                "bucket",
-                &[-8, 0],
-            )),
+            buckets: Some(Buckets::new(BucketMethod::CumulFreq, "bucket", &[-8, 0])),
         }],
     ); // LCOV_EXCL_LINE Kcov bug?
 }


### PR DESCRIPTION
Regression caused by a fix to slowg at https://github.com/slog-rs/slog/commit/763773b9a13e5345a38f62c4b5459d94706c025c

Previously `Level::from_str` only did a shortest-length-match - now it does an exact match so "Warning" is no longer a valid input.  To keep the API to `slog-extlog-derive` the same, handle that case specially.

Bump a new patch release as well.

Test changes are just from running `rustfmt`.