### PR TITLE
Add getText method to ExtLoggables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.3.0]
+### Added
+- Added `getText` method to structs which are `ExtLoggable`, so that log text can be re-used in the application without copying.
+
 ## [5.2.1]
 ### Changed
 - Ensure that derive log level handling still works with `slog` 2.5.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Metaswitch Networks Ltd"]
 name = "slog-extlog"
-version = "5.2.1"
+version = "5.3.0"
 license = "Apache-2.0"
 description = "Object-based logging and statistics tracking through logs"
 homepage = "https://github.com/slog-rs/extlog"

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-extlog-derive"
-version = "5.2.1"
+version = "5.3.0"
 authors = ["Metaswitch Networks Ltd"]
 license = "Apache-2.0"
 description = "Custom derive code for slog-extlog"

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -505,6 +505,9 @@ fn impl_loggable(ast: &syn::DeriveInput) -> quote::Tokens {
     let (tys, bounds) = get_types_bounds(ty_params);
     let tys_2 = tys.clone();
     let tys_3 = tys.clone();
+    let tys_4 = tys.clone();
+    let tys_5 = tys.clone();
+    let tys_6 = tys.clone();
 
     // Get the log details from the attribute.
     let vals = ast
@@ -579,6 +582,13 @@ fn impl_loggable(ast: &syn::DeriveInput) -> quote::Tokens {
         #kv_gen
 
         #stat_gen
+
+        impl<#(#lifetimes,)* #(#tys_4),*> #name<#(#lifetimes,)* #(#tys_5),*> {
+            /// Retrieve the contents of the "Text" field associated with this log.
+            pub fn getText<#(#lifetimes,)* #(#tys_6),*>() -> &'static str {
+                return #text;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Added `getText` method to structs which are `ExtLoggable`, so that log text can be re-used in the application without copying.

Signed-off-by: Nigel Thorpe <nigel.thorpe@metaswitch.com>