### PR TITLE
Run stricter lints and adds missing docs to public items

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,21 @@
+# Cargo configuration
+
+[build]
+
+rustflags = [
+
+    "-W", "missing_docs",  # detects missing documentation for public members
+
+    "-W", "trivial_casts",  # detects trivial casts which could be removed
+
+    "-W", "trivial_numeric_casts",  # detects trivial casts of numeric types which could be removed
+
+    "-W", "unsafe_code",  # usage of `unsafe` code
+
+    "-W", "unused_qualifications",  # detects unnecessarily qualified names
+
+    "-W", "unused_extern_crates",  # extern crates that are never used
+
+    "-W", "unused_import_braces",  # unnecessary braces around an imported item
+
+    ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Add comment to statics created through `define_stats` macro to prevent downstream clippy failures. Also add a `.cargo/config` turning on some common warnings (and fix up code, mainly comments).
+- 
 
 ## [5.2.1]
 ### Changed

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -1,6 +1,8 @@
 //! Benchmarks for stats
 //!
 
+#![allow(missing_docs)]
+
 use serde::Serialize;
 use tokio_core::reactor::Core;
 

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -141,7 +141,7 @@ fn test_fixed_field() {
 
 #[test]
 fn test_generics() {
-    // Currently, fields with lifetimes cannot be used as slog::Value, becuase we need a way to
+    // Currently, fields with lifetimes cannot be used as slog::Value, because we need a way to
     // convert to a static lifetime.  Can try by making FooData have a lifetime parameter for the
     // "desc" field.
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -82,7 +82,7 @@ pub trait StatDefinition: fmt::Debug {
 /// ```text
 ///   define_stats!{
 ///      STATS_LIST_NAME = {
-///          StatName(Type, "Description", ["tag1, "tag2", ...]),
+///          StatName(Type, "Description", ["tag1", "tag2", ...]),
 ///          StatName2(...),
 ///          ...
 ///      }
@@ -112,9 +112,9 @@ pub trait StatDefinition: fmt::Debug {
 ///     also be provided like so:
 ///
 /// ```text
-///   define_stats!{
+///    define_stats!{
 ///      STATS_LIST_NAME = {
-///          StatName(BucketCounter, "Description", ["tag1, "tag2", ...], (BucketMethod, "bucket_label", [1, 2, 3, ...])),
+///          StatName(BucketCounter, "Description", ["tag1", "tag2", ...], (BucketMethod, "bucket_label", [1, 2, 3, ...])),
 ///          StatName2(...),
 ///          ...
 ///      }
@@ -128,12 +128,12 @@ pub trait StatDefinition: fmt::Debug {
 ///   - The bucket label should describe what the buckets measure and should be distinct from the tags.
 ///     Each stat log will be labelled with the pair `(bucket_label, bucket_value)` in addition to the tags,
 ///     where `bucket_value` is the numerical value of the bucket the log falls into.
-
 #[macro_export]
 macro_rules! define_stats {
 
     // Entry point - match each individual stat name and pass on the details for further parsing
     ($name:ident = {$($stat:ident($($details:tt),*)),*}) => {
+        /// A vector of stats that can be passed in as the `stats` field on a `StatsConfig` object.
         pub static $name: $crate::stats::StatDefinitions = &[$(&$stat),*];
 
         mod inner_stats {
@@ -214,7 +214,7 @@ pub trait StatTrigger {
         false
     }
     /// Get the associated tag value for this log.
-    /// The value must be convertable to a string so it can be stored internally.
+    /// The value must be convertible to a string so it can be stored internally.
     fn tag_value(&self, stat_id: &StatDefinitionTagged, _tag_name: &'static str) -> String;
     /// The details of the change to make for this stat, if `condition` returned true.
     fn change(&self, _stat_id: &StatDefinitionTagged) -> Option<ChangeType> {
@@ -381,7 +381,7 @@ pub struct StatsTracker<T: StatisticsLogFormatter> {
     stats: HashMap<&'static str, Stat>,
 
     // The callback to make for logging the statistic.  This is a marker type so store it
-    // as phatom.
+    // as phantom.
     stat_formatter: PhantomData<T>,
 }
 // LCOV_EXCL_STOP
@@ -534,13 +534,11 @@ where
 ///     }
 /// }
 ///
-/// fn main() {
-///     let full_stats = vec![MY_STATS];
-///     let cfg = StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
-///                  .with_stats(full_stats)
-///                  .with_log_interval(30)
-///                  .fuse();
-/// }
+/// let full_stats = vec![MY_STATS];
+/// let cfg = StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
+///              .with_stats(full_stats)
+///              .with_log_interval(30)
+///              .fuse();
 /// ```
 pub struct StatsConfigBuilder<T: StatisticsLogFormatter> {
     cfg: StatsConfig<T>,
@@ -796,12 +794,16 @@ where
 /// The values contained in a `StatSnapshot` for each stat type.
 #[derive(Debug)]
 pub enum StatSnapshotValues {
+    /// `StatSnapshot` values for the Counter stat type.
     Counter(Vec<StatSnapshotValue>),
+    /// `StatSnapshot` values for the Gauge stat type.
     Gauge(Vec<StatSnapshotValue>),
+    /// Bucket description, and `StatSnapshot` values by bucket for the BucketCounter stat type.
     BucketCounter(Buckets, Vec<(StatSnapshotValue, BucketLimit)>),
 }
 
 impl StatSnapshotValues {
+    /// Returns true if self contains no StatSnapshotValue entries.
     pub fn is_empty(&self) -> bool {
         match self {
             StatSnapshotValues::Counter(ref vals) | StatSnapshotValues::Gauge(ref vals) => {
@@ -816,7 +818,9 @@ impl StatSnapshotValues {
 // LCOV_EXCL_START not interesting to track automatic derive coverage
 #[derive(Debug)]
 pub struct StatSnapshot {
+    /// A configured statistic, defined in terms of the external logs that trigger it to change.
     pub definition: &'static dyn StatDefinition,
+    /// The values contained in a `StatSnapshot` for each stat type.
     pub values: StatSnapshotValues,
 }
 // LCOV_EXCL_STOP
@@ -833,7 +837,11 @@ impl StatSnapshot {
 // LCOV_EXCL_START not interesting to track automatic derive coverage
 #[derive(Debug)]
 pub struct StatSnapshotValue {
+    /// A vec of the set of tags that this value belongs to. A group can have several tags
+    /// and the stat is counted separately for all distinct combinations of tag values.
+    /// This may be an empty vec is the stat is not grouped.
     pub group_values: Vec<String>,
+    /// The value of the stat with the above combination of groups (note that this may be bucketed).
     pub value: f64,
 }
 // LCOV_EXCL_STOP
@@ -1190,7 +1198,7 @@ impl Stat {
             // It's possible that while we were waiting for the write lock another thread got
             // in and created the stat entry, so check again.
             let val = inner_vals
-                .entry(tag_values.to_string())
+                .entry(tag_values)
                 .or_insert_with(|| StatValue::new(0, 1));
 
             val.update(&change);
@@ -1310,6 +1318,7 @@ mod tests {
             StatsConfigBuilder::<DummyNonCloneFormatter>::new().fuse(),
         );
 
-        let _new_logger: StatisticsLogger<DummyNonCloneFormatter> = logger.clone();
+        fn is_clone<T: Clone>(_: &T) {}
+        is_clone(&logger);
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1234,7 +1234,7 @@ impl Stat {
                 } else {
                     vec![]
                 };
-                (StatSnapshotValue::new(group_values, *value))
+                StatSnapshotValue::new(group_values, *value)
             })
             .collect()
     }

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -270,7 +270,7 @@ fn test_extloggable_strings() {
 }
 
 #[test]
-fn test_extloggable_setto() {
+fn test_extloggable_set_to() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     xlog!(
@@ -881,7 +881,7 @@ fn unwind_safety_works() {
 #[test]
 fn multiple_stats_defns() {
     #[derive(ExtLoggable, Clone, Serialize)]
-    #[LogDetails(Id = "100", Text = "Soemthing special happened", Level = "Info")]
+    #[LogDetails(Id = "100", Text = "Something special happened", Level = "Info")]
     #[StatTrigger(StatName = "test_special_counter", Action = "Incr", Value = "1")]
     struct SpecialLog;
 

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -6,7 +6,6 @@ use slog_extlog::{define_stats, xlog};
 use slog_extlog_derive::ExtLoggable;
 
 use slog_extlog::slog_test::*;
-use slog_extlog::stats;
 use slog_extlog::stats::StatType::{BucketCounter, Counter, Gauge};
 use std::str;
 
@@ -127,7 +126,7 @@ struct GroupBucketCounterLog {
 
 #[test]
 fn request_with_no_stats() {
-    let (logger, _) = create_logger_buffer(stats::EMPTY_STATS);
+    let (logger, _) = create_logger_buffer(EMPTY_STATS);
     let stats = logger.get_stats();
 
     assert_eq!(stats.len(), 0);
@@ -139,7 +138,7 @@ fn request_for_single_counter() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_counter",
@@ -161,7 +160,7 @@ fn request_for_single_gauge() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_gauge",
@@ -183,7 +182,7 @@ fn request_for_multiple_metrics() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[
             ExpectedStatSnapshot {
@@ -222,7 +221,7 @@ fn request_for_updated_metrics() {
 
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[
             ExpectedStatSnapshot {
@@ -257,7 +256,7 @@ fn request_for_single_counter_with_groups_but_no_values() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_grouped_counter",
@@ -275,7 +274,7 @@ fn request_for_single_gauge_with_groups_but_no_values() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_grouped_gauge",
@@ -302,7 +301,7 @@ fn request_for_single_counter_with_groups_and_one_value() {
     );
 
     let stats = logger.get_stats();
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_grouped_counter",
@@ -333,7 +332,7 @@ fn request_for_single_gauge_with_groups_and_one_value() {
     );
 
     let stats = logger.get_stats();
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_grouped_gauge",
@@ -373,7 +372,7 @@ fn request_for_single_counter_with_groups_and_two_values() {
     );
 
     let stats = logger.get_stats();
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_grouped_counter",
@@ -402,7 +401,7 @@ fn request_for_bucket_counter_freq() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_bucket_counter_freq",
@@ -444,7 +443,7 @@ fn request_for_bucket_counter_freq_one_value() {
 
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_bucket_counter_freq",
@@ -483,7 +482,7 @@ fn request_for_bucket_counter_cumul_freq() {
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_bucket_counter_cumul_freq",
@@ -546,7 +545,7 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
 
     let stats = logger.get_stats();
 
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[ExpectedStatSnapshot {
             name: "test_group_bucket_counter",
@@ -631,7 +630,7 @@ fn request_for_many_metrics() {
     );
 
     let stats = logger.get_stats();
-    check_expected_stat_snaphots(
+    check_expected_stat_snapshots(
         &stats,
         &[
             ExpectedStatSnapshot {


### PR DESCRIPTION
Libraries should have docs for all their public items.
This pull request
- adds in some missing docs (including to the macro `define_stats` which was causing downstream missing-docs lint failures),
- and adds a `.cargo/config` file which runs a few extra lints - including for missing docs in public items.

