### PR TITLE
Don't fail tests if a JSON log is only partially written

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - rustup component add clippy
 script:
 - |
-  DCO_SIGNING_BASE_COMMIT=e0b3f43a21490d815697a185e4a48c269859cbc4 &&
+  DCO_SIGNING_BASE_COMMIT=4c9e80eb9ddb5f97e2e55c63a8cfb258897ceac5 &&
   if git log ${DCO_SIGNING_BASE_COMMIT}.. --grep "^signed-off-by: .\+@.\+" --regexp-ignore-case --invert-grep --no-merges | grep ^ ;
   then echo '**One or more commits are not signed off!' ; /bin/false ; fi
 - cargo clippy --all-targets --all-features --all -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Add comment to statics created through `define_stats` macro to prevent downstream clippy failures. Also add a `.cargo/config` turning on some common warnings (and fix up code, mainly comments).
 - `slog_test` test methods: don't panic if log is partially written in another thread, but leave partial data for next read.
-  This is a breaking change if you use `slog_test`; change
-  ```
-  let data = iobuffer::IoBuffer::new();
-  let logger = slog_test::new_test_logger(data.clone())
-  ```
-  to
-  ```
-  let (logger, mut data) = slog_test::new_test_logger();
-  ```
-  Methods `read_json_values` and `logs_in_range` now accept only an `IoBuffer`.
+  Technically this is a breaking change if you use `slog_test`, since
+  methods `new_test_logger`, `read_json_values` and `logs_in_range` now accept
+  only an `IoBuffer`. However in practice callers almost certainly passed an
+  `IoBuffer` already.
 
 ## [5.2.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Add comment to statics created through `define_stats` macro to prevent downstream clippy failures. Also add a `.cargo/config` turning on some common warnings (and fix up code, mainly comments).
-- 
+- `slog_test` test methods: don't panic if log is partially written in another thread, but leave partial data for next read.
+  This is a breaking change if you use `slog_test`; change
+  ```
+  let data = iobuffer::IoBuffer::new();
+  let logger = slog_test::new_test_logger(data.clone())
+  ```
+  to
+  ```
+  let (logger, mut data) = slog_test::new_test_logger();
+  ```
+  Methods `read_json_values` and `logs_in_range` now accept only an `IoBuffer`.
 
 ## [5.2.1]
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ name = "stats"
 [dependencies]
 erased-serde = "0.3"
 futures = "0.1"
-iobuffer= "0.1"
+# TODO fixme when iobuffer 0.2 released
+# iobuffer = "0.1"
+iobuffer = { git = "https://github.com/kw217/iobuffer", branch = "parse-full-lines" }
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio-core = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ name = "stats"
 [dependencies]
 erased-serde = "0.3"
 futures = "0.1"
-# TODO fixme when iobuffer 0.2 released
-# iobuffer = "0.1"
-iobuffer = { git = "https://github.com/kw217/iobuffer", branch = "parse-full-lines" }
+iobuffer = "0.2"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio-core = "0.1"

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -22,4 +22,4 @@ proc-macro = true
 
 [dev-dependencies]
 erased-serde = "0.3"
-iobuffer = "0.1"
+iobuffer = "0.2"

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -156,7 +156,6 @@
 
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -17,9 +17,8 @@ const CRATE_LOG_NAME: &str = "SLOGTST";
 
 // Helper to create a logger and matching Ring buffer to store them.
 fn create_logger(testname: &'static str) -> (Logger, iobuffer::IoBuffer) {
-    let data = iobuffer::IoBuffer::new();
-    let logger = slog_test::new_test_logger(data.clone()).new(o!("testname" => testname));
-    (logger, data)
+    let (logger, data) = slog_test::new_test_logger();
+    (logger.new(o!("testname" => testname)), data)
 }
 
 #[test]

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -17,8 +17,9 @@ const CRATE_LOG_NAME: &str = "SLOGTST";
 
 // Helper to create a logger and matching Ring buffer to store them.
 fn create_logger(testname: &'static str) -> (Logger, iobuffer::IoBuffer) {
-    let (logger, data) = slog_test::new_test_logger();
-    (logger.new(o!("testname" => testname)), data)
+    let data = iobuffer::IoBuffer::new();
+    let logger = slog_test::new_test_logger(data.clone()).new(o!("testname" => testname));
+    (logger, data)
 }
 
 #[test]

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -4,8 +4,8 @@
 //! Helper functions for use when testing slog logs.
 //!
 //! This module is a grab-bag of tools that have been found useful when testing slog logs.
-//! A typical test will create a new `iobuffer::IoBuffer`, pass it to `new_test_logger` to
-//! construct a logger, and pass that logger to the system under test. It will then exercise
+//! A typical test will use `new_test_logger` to construct a logger and buffer,
+//! and pass that logger to the system under test. It will then exercise
 //! the system. Finally, it will use `logs_in_range` to extract the logs it is interested in
 //! in a canonical order, and test that they are as expected using standard Rust tools.
 //!
@@ -15,8 +15,7 @@
 //! use slog_extlog::slog_test;
 //!
 //! // Setup code
-//! let mut data = iobuffer::IoBuffer::new();
-//! let logger = slog_test::new_test_logger(data.clone());
+//! let (logger, mut data) = slog_test::new_test_logger();
 //!
 //! // Application code
 //! debug!(logger, "Something happened to it";
@@ -48,27 +47,31 @@
 pub use super::stats::*;
 
 use slog::o;
-use std::io;
 #[allow(unused_imports)] // we need this trait for lines()
 use std::io::BufRead;
 use std::sync::Mutex;
 
+/// Buffer containing log data.
+pub type Buffer = iobuffer::IoBuffer;
+
 /// Create a new test logger suitable for use with `read_json_values`.
-pub fn new_test_logger<T: io::Write + Send + 'static>(stream: T) -> slog::Logger {
-    slog::Logger::root(
-        slog::Fuse::new(Mutex::new(slog_json::Json::default(stream))),
-        o!(),
-    ) // LCOV_EXCL_LINE kcov bug?
+pub fn new_test_logger() -> (slog::Logger, Buffer) {
+    let data = iobuffer::IoBuffer::new();
+    (
+        slog::Logger::root(
+            slog::Fuse::new(Mutex::new(slog_json::Json::default(data.clone()))),
+            o!(),
+        ),
+        data,
+    )
 }
 
 /// Read all the newline-delimited JSON objects from the given stream,
 /// panicking if there is an IO error or a JSON parse error.
 /// No attempt is made to avoid reading partial lines from the stream.
-pub fn read_json_values(data: &mut dyn io::Read) -> Vec<serde_json::Value> {
-    let reader = io::BufReader::new(data);
-    let iter = reader.lines().map(move |line| {
-        serde_json::from_str::<serde_json::Value>(&line.expect("IO error"))
-            .expect("JSON parse error")
+pub fn read_json_values(data: &mut Buffer) -> Vec<serde_json::Value> {
+    let iter = data.lines().map(move |line| {
+        serde_json::from_slice::<serde_json::Value>(&line).expect("JSON parse error")
     });
     iter.collect()
 }
@@ -84,11 +87,7 @@ pub fn log_in_range(min_id: &str, max_id: &str, log: &serde_json::Value) -> bool
 
 /// Collect all logs of the indicated type (see `log_in_range`) and sort them in
 /// ascending order of log_id.
-pub fn logs_in_range(
-    min_id: &str,
-    max_id: &str,
-    data: &mut dyn io::Read,
-) -> Vec<serde_json::Value> {
+pub fn logs_in_range(min_id: &str, max_id: &str, data: &mut Buffer) -> Vec<serde_json::Value> {
     let mut v = read_json_values(data)
         .into_iter()
         .filter(|log| log_in_range(min_id, max_id, log))
@@ -135,16 +134,12 @@ pub static TEST_LOG_INTERVAL: u64 = 5;
 
 /// Common setup function.
 ///
-/// Creates a logger using the provided statistics and an `IoBuffer` so we can easily
+/// Creates a logger using the provided statistics and buffer so we can easily
 /// view the generated logs.
 pub fn create_logger_buffer(
     stats: StatDefinitions,
-) -> (
-    StatisticsLogger<DefaultStatisticsLogFormatter>,
-    iobuffer::IoBuffer,
-) {
-    let data = iobuffer::IoBuffer::new();
-    let logger = new_test_logger(data.clone());
+) -> (StatisticsLogger<DefaultStatisticsLogFormatter>, Buffer) {
+    let (logger, data) = new_test_logger();
 
     let logger = StatisticsLogger::new(
         logger,
@@ -318,4 +313,48 @@ pub fn check_expected_stat_snapshots(
     }
 
     assert_eq!(stats.len(), expected_stats.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slog::debug;
+    use std::sync::mpsc;
+    use std::thread;
+
+    /// Ensure that partial writes don't cause JSON parsing errors.
+    #[test]
+    fn test_partial_write() {
+        // Set up the logger.
+        let (logger, mut data) = new_test_logger();
+
+        let (started_send, started_recv) = mpsc::channel();
+        let (done_send, done_recv) = mpsc::channel();
+
+        // In a separate thread, repeatedly write JSON values until
+        // told to stop. There are lots of fields, and serde `write()`s each
+        // value separately, so there's plenty of opportunity for reading an
+        // incomplete record.
+        let _ = thread::spawn(move || {
+            let _ = started_send.send(()).unwrap();
+            while done_recv.try_recv().is_err() {
+                debug!(logger, "Some data";
+                       "alfa" => "alpha",
+                       "bravo" => "beta",
+                       "charlie" => "gamma",
+                       "delta" => "delta",
+                       "echo" => "epsilon");
+            }
+        });
+
+        // Wait until the thread has started.
+        started_recv.recv().unwrap();
+
+        // Now try to read some values. This should not fail with a parse
+        // error.
+        let _ = read_json_values(&mut data);
+
+        // Tell the daemon thread to stop so as not to leak CPU/memory.
+        done_send.send(()).unwrap();
+    }
 }

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -335,7 +335,7 @@ mod tests {
         // value separately, so there's plenty of opportunity for reading an
         // incomplete record.
         let _ = thread::spawn(move || {
-            let _ = started_send.send(()).unwrap();
+            started_send.send(()).unwrap();
             while done_recv.try_recv().is_err() {
                 debug!(logger, "Some data";
                        "alfa" => "alpha",

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -25,14 +25,10 @@
 //! [`slog-extlog-derive`]: ../../slog_extlog_derive/index.html
 //! [`StatisticsLogger`]: ./struct.StatisticsLogger.html
 
-use futures;
-use tokio_core;
-use tokio_timer;
-
-use self::futures::stream::Stream;
-use self::futures::Future;
-use self::tokio_core::reactor::{Core, Handle};
-use self::tokio_timer::Timer;
+use futures::stream::Stream;
+use futures::Future;
+use tokio_core::reactor::{Core, Handle};
+use tokio_timer::Timer;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;

--- a/tests/demo_test.rs
+++ b/tests/demo_test.rs
@@ -14,7 +14,8 @@ use slog_extlog::slog_test;
 #[test]
 fn test_main() {
     // Setup code
-    let (logger, mut data) = slog_test::new_test_logger();
+    let mut data = iobuffer::IoBuffer::new();
+    let logger = slog_test::new_test_logger(data.clone());
 
     // Application code
     debug!(logger, "Something happened to it";

--- a/tests/demo_test.rs
+++ b/tests/demo_test.rs
@@ -6,7 +6,6 @@
 //! doc-tests. This should be removed once that is fixed.
 //! See https://github.com/kennytm/cargo-kcov/issues/15
 
-use iobuffer;
 use serde_json::json;
 
 use slog::debug;
@@ -15,8 +14,7 @@ use slog_extlog::slog_test;
 #[test]
 fn test_main() {
     // Setup code
-    let mut data = iobuffer::IoBuffer::new();
-    let logger = slog_test::new_test_logger(data.clone());
+    let (logger, mut data) = slog_test::new_test_logger();
 
     // Application code
     debug!(logger, "Something happened to it";

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -884,7 +884,8 @@ fn multiple_stats_defns() {
         }
     }
 
-    let (logger, mut data) = new_test_logger();
+    let mut data = iobuffer::IoBuffer::new();
+    let logger = new_test_logger(data.clone());
 
     let logger = StatisticsLogger::new(
         logger,

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -184,10 +184,7 @@ fn log_external_grouped(
 }
 
 // Retrieves logs for a given statistic.
-fn get_stat_logs(
-    stat_name: &'static str,
-    mut data: &mut iobuffer::IoBuffer,
-) -> Vec<serde_json::Value> {
+fn get_stat_logs(stat_name: &'static str, mut data: &mut Buffer) -> Vec<serde_json::Value> {
     logs_in_range("STATS-1", "STATS-2", &mut data)
         .iter()
         .cloned()
@@ -196,12 +193,7 @@ fn get_stat_logs(
 }
 
 // Does the work of checking that we get the expected values in our logs.
-fn check_log_fields(
-    stat_name: &'static str,
-    data: &mut iobuffer::IoBuffer,
-    metric_type: &str,
-    value: f64,
-) {
+fn check_log_fields(stat_name: &'static str, data: &mut Buffer, metric_type: &str, value: f64) {
     thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
 
     let logs = get_stat_logs(stat_name, data);
@@ -892,8 +884,7 @@ fn multiple_stats_defns() {
         }
     }
 
-    let mut data = iobuffer::IoBuffer::new();
-    let logger = new_test_logger(data.clone());
+    let (logger, mut data) = new_test_logger();
 
     let logger = StatisticsLogger::new(
         logger,


### PR DESCRIPTION
Ensure that we don't panic with a parse error when reading JSON logs at the same time as they are being written, due to partially-written JSON. This is a breaking change for `slog_test` users because the signature of `new_test_logger` is changed.

Includes a test demonstrating the problem, which reliably failed before the fix.

Obviously dependent on https://github.com/Metaswitch/iobuffer/pull/1 - I'll fix `Cargo.toml` once that is merged and released, before this can be merged.