### PR TITLE
Revamp StatisticsLogger creation API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - rustup component add clippy
 script:
 - |
-  DCO_SIGNING_BASE_COMMIT=4c9e80eb9ddb5f97e2e55c63a8cfb258897ceac5 &&
+  DCO_SIGNING_BASE_COMMIT=b00f12dc7afa4400af1289a7f69e570148ae16e5 &&
   if git log ${DCO_SIGNING_BASE_COMMIT}.. --grep "^signed-off-by: .\+@.\+" --regexp-ignore-case --invert-grep --no-merges | grep ^ ;
   then echo '**One or more commits are not signed off!' ; /bin/false ; fi
 - cargo clippy --all-targets --all-features --all -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Update to `tokio` 1.0
+  - Breaking for users who pass in their own `tokio::runtime::Handle` to
+    `StatsConfig`, otherwise transparent.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- The statistics interval logging function is behind a feature flag (`interval_logging`) this allows users of the crate who are simply using the derive macros or `xlog!` to not have to pull in a whole `tokio` runtime.
 - `StatisticsLogger` creation API has changed:
     - Removed `StatsConfig` and `StatsConfigBuilder`
-    - Added `StatsLoggerBuilder` with `fuse(logger)` to create the
-      `StatisticsLogger`
-    - Creating a `StatisticsLogger` must be done within a `tokio v1.0` runtime
-    - if the interval logging is enabled
-- `slog_extlog` re-exports the `#[derive(ExtLoggable)]` and
-  `#[derive(SlogValue)]` macros so no need to depend explicitly on
-  `slog_extlog_derive` any more
+    - Added `StatsLoggerBuilder` with `fuse(logger)` to create the `StatisticsLogger`
+    - Creating a `StatisticsLogger` must be done within a `tokio v1.0` runtime if the interval logging is enabled
+- `slog_extlog` re-exports the `#[derive(ExtLoggable)]` and `#[derive(SlogValue)]` macros so there's no need to depend explicitly on `slog_extlog_derive` any more
 
 ## [6.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Update to `tokio` 1.0
-  - Breaking for users who pass in their own `tokio::runtime::Handle` to
-    `StatsConfig`, otherwise transparent.
-
-### Added
-
-### Fixed
+- `StatisticsLogger` creation API has changed:
+    - Removed `StatsConfig` and `StatsConfigBuilder`
+    - Added `StatsLoggerBuilder` with `fuse(logger)` to create the
+      `StatisticsLogger`
+    - Creating a `StatisticsLogger` must be done within a `tokio v1.0` runtime
+    - if the interval logging is enabled
+- `slog_extlog` re-exports the `#[derive(ExtLoggable)]` and
+  `#[derive(SlogValue)]` macros so no need to depend explicitly on
+  `slog_extlog_derive` any more
 
 ## [6.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Update to `tokio` 1.0
+
 ### Added
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ harness = false
 name = "stats"
 
 [dependencies]
-erased-serde = "0.3"
-futures = "0.3.5"
 iobuffer = "0.2"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tokio = {version = "0.2.22", features = ["rt-core", "stream", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
 [dependencies.slog]
 features = ["nested-values"]
@@ -32,6 +30,7 @@ version = "2.1"
 
 [dev-dependencies]
 bencher = "0.1.5"
+erased-serde = "0.3"
 
 # Cargo doesn't let you publish crates with circular dev dependencies,
 # so in order to publish new versions you'll need to temporarily comment out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ name = "stats"
 iobuffer = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+
+# Used by the interval_logging feature
+tokio = { version = "1", features = ["rt", "time"], optional = true }
 
 # The version here is pinned hard to the same version as this crate
 # this is to allow the derive <-> extlog crate APIs to stay perfectly in sync,
@@ -38,7 +40,10 @@ version = "2.1"
 [dev-dependencies]
 bencher = "0.1.5"
 erased-serde = "0.3"
-tokio = { version = "1", features = [ "macros" ] }
+tokio = { version = "1", features = [ "macros", "rt-multi-thread", "time" ] }
+
+[features]
+interval_logging = [ "tokio" ]
 
 [workspace]
 members = ["slog-extlog-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
+# The version here is pinned hard to the same version as this crate
+# this is to allow the derive <-> extlog crate APIs to stay perfectly in sync,
+# allowing breaking changes that only affect each other to be elided
+[dependencies.slog-extlog-derive]
+version = "=6.0.1"
+path = "slog-extlog-derive"
+
 [dependencies.slog]
 features = ["nested-values"]
 version = "2.4"
@@ -31,17 +38,7 @@ version = "2.1"
 [dev-dependencies]
 bencher = "0.1.5"
 erased-serde = "0.3"
-
-# Cargo doesn't let you publish crates with circular dev dependencies,
-# so in order to publish new versions you'll need to temporarily comment out
-# this dependency in your local codebase and publish the crate using the
-# --allow-dirty flag.
-#
-# This is a known problem in Cargo - see
-# https://github.com/rust-lang/cargo/issues/4242 for tracking issue.
-[dev-dependencies.slog-extlog-derive]
-version = "6"
-path = "slog-extlog-derive"
+tokio = { version = "1", features = [ "macros" ] }
 
 [workspace]
 members = ["slog-extlog-derive"]

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -4,8 +4,6 @@
 #![allow(missing_docs)]
 
 use serde::Serialize;
-use tokio::runtime::Runtime;
-
 use bencher::Bencher;
 use slog_extlog::stats::*;
 use slog_extlog::xlog;
@@ -68,15 +66,10 @@ struct FourthExternalLog {
 //LCOV_EXCL_STOP
 
 fn setup_logger() -> StatisticsLogger<DefaultStatisticsLogFormatter> {
-    // Use the same tokio runtime for speed.
-    let runtime = Runtime::new().expect("Failed to initialize tokio runtime");
-    StatisticsLogger::new(
-        slog::Logger::root(slog::Discard, slog::o!()),
-        StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
-            .with_stats(vec![SLOG_TEST_STATS])
-            .with_runtime(runtime.handle().clone())
-            .fuse(), // LCOV_EXCL_LINE Kcov bug?
-    )
+    StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
+        .with_stats(vec![SLOG_TEST_STATS])
+        .without_interval_logs()
+        .fuse(slog::Logger::root(slog::Discard, slog::o!()))
 }
 
 // Benchmark a log that increments a counter unconditionally.

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -3,8 +3,8 @@
 
 #![allow(missing_docs)]
 
-use serde::Serialize;
 use bencher::Bencher;
+use serde::Serialize;
 use slog_extlog::stats::*;
 use slog_extlog::xlog;
 use slog_extlog_derive::ExtLoggable;
@@ -68,7 +68,6 @@ struct FourthExternalLog {
 fn setup_logger() -> StatisticsLogger<DefaultStatisticsLogFormatter> {
     StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
         .with_stats(vec![SLOG_TEST_STATS])
-        .without_interval_logs()
         .fuse(slog::Logger::root(slog::Discard, slog::o!()))
 }
 

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -24,3 +24,4 @@ erased-serde = "0.3"
 iobuffer = "0.2"
 serde =  { version = "1.0", features = ["derive"] }
 slog-extlog = { version = "6", path = ".." }
+tokio = { version = "1.0", features = ["macros"] }

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -13,10 +13,8 @@ edition = "2018"
 [dependencies]
 proc-macro2 = "1.0.19"
 slog = { version = "2.4", features = ['nested-values'] }
-syn = {version = "1.0.36", features = ["full"] }
+syn = { version = "1.0.36", features = ["full"] }
 quote = "1.0.7"
-slog-extlog = { version = "6", path = ".." }
-serde = {version = "1.0", features = ["derive"] }
 
 [lib]
 proc-macro = true
@@ -24,3 +22,5 @@ proc-macro = true
 [dev-dependencies]
 erased-serde = "0.3"
 iobuffer = "0.2"
+serde =  { version = "1.0", features = ["derive"] }
+slog-extlog = { version = "6", path = ".." }

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -160,7 +160,6 @@
 extern crate quote;
 
 use proc_macro::TokenStream;
-use proc_macro2;
 use slog::Level;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -187,7 +187,7 @@ impl FromStr for StatTriggerAction {
 
 enum StatTriggerValue {
     Fixed(i64),
-    Expr(syn::Expr),
+    Expr(Box<syn::Expr>),
 }
 
 // Info about a statistic trigger

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -95,7 +95,8 @@
 //! #[LogDetails(Id="103", Text="Foo response sent", Level="Info")]
 //! struct FooRspSent(FooRspCode);
 //!
-//! # fn main() { }
+//! # #[tokio::main]
+//! # async fn main() { }
 //! ```
 //!
 //! Defining some statistics from a single log.
@@ -104,7 +105,7 @@
 //! use slog_extlog_derive::{ExtLoggable, SlogValue};
 //! use serde::Serialize;
 //!
-//! use slog_extlog::{define_stats, ExtLoggable, stats, xlog};
+//! use slog_extlog::{define_stats, stats, xlog};
 //! use slog_extlog::stats::{Buckets, StatDefinition};
 //! use slog::o;
 //!
@@ -133,13 +134,13 @@
 //!   user: String
 //! }
 //!
-//! fn main() {
-//!   let cfg = stats::StatsConfigBuilder::<stats::DefaultStatisticsLogFormatter>::new().
-//!       with_stats(vec![FOO_STATS]).fuse();
-//!
+//! # #[tokio::main]
+//! async fn main() {
 //!   // Create the logger using whatever log format required.
 //!   let slog_logger = slog::Logger::root(slog::Discard, o!());
-//!   let logger = stats::StatisticsLogger::new(slog_logger, cfg);
+//!   let logger: slog_extlog::DefaultLogger = stats::StatsLoggerBuilder::default()
+//!       .with_stats(vec![FOO_STATS])
+//!       .fuse(slog_logger);
 //!
 //!   // Now all logs of `FooReqRcvd` will increment the `FooNonEmptyCount` and
 //!   // `FooTotalBytesByUser` stats...
@@ -702,17 +703,12 @@ fn is_attr_stat_id(attr: &syn::Attribute, id: &syn::Ident) -> bool {
     match attr.parse_meta() {
         // We only care about the case where this is a list of key-value type attributes.
         Ok(syn::Meta::List(ref list)) => list.nested.iter().any(|inner| {
-            if let syn::NestedMeta::Meta(ref item) = *inner {
-                match *item {
-                    syn::Meta::NameValue(ref name_value) => {
-                        if let syn::Lit::Str(ref s) = name_value.lit {
-                            let parsed_value = format_ident!("{}", s.value());
-                            name_value.path.is_ident("StatName") && &parsed_value == id
-                        } else {
-                            false
-                        }
-                    }
-                    _ => false,
+            if let syn::NestedMeta::Meta(syn::Meta::NameValue(ref name_value)) = *inner {
+                if let syn::Lit::Str(ref s) = name_value.lit {
+                    let parsed_value = format_ident!("{}", s.value());
+                    name_value.path.is_ident("StatName") && &parsed_value == id
+                } else {
+                    false
                 }
             } else {
                 false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! ```
 //! use serde::Serialize;
-//! use slog_extlog::{DefaultLogger, define_stats, xlog};
+//! use slog_extlog::{DefaultLogger, stats::StatsLoggerBuilder, define_stats, xlog};
 //! use slog_extlog_derive::{ExtLoggable, SlogValue};
 //!
 //! use slog::{Drain, debug, info, o};
@@ -113,19 +113,17 @@
 //!
 //! const CRATE_LOG_NAME: &'static str = "FOO";
 //!
-//! fn main() {
-//!
+//! #[tokio::main]
+//! async fn main() {
 //!     // Use a basic logger with some context.
 //!     let logger = slog::Logger::root(
 //!         Mutex::new(slog_json::Json::default(std::io::stdout())).map(slog::Fuse),
 //!         o!());
-//!     let foo_logger = DefaultLogger::new(
-//!                        logger.new(o!("cxt" =>
-//!                          FooContext {
-//!                            id: "123456789".to_string(),
-//!                            method: FooMethod::POST,
-//!                          })),
-//!                        Default::default());
+//!     let logger = logger.new(o!("cxt" => FooContext {
+//!         id: "123456789".to_string(),
+//!         method: FooMethod::POST,
+//!     }));
+//!     let foo_logger: DefaultLogger = StatsLoggerBuilder::default().fuse(logger);
 //!
 //!     // Now make some logs...
 //!     xlog!(foo_logger, FooReqRcvd);
@@ -231,3 +229,6 @@ macro_rules! impl_value_wrapper {
         }
     };
 }
+
+// Re-export the derive macros to ensure that version compatibility is preserved
+pub use slog_extlog_derive::{ExtLoggable, SlogValue};

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -139,10 +139,12 @@ pub fn create_logger_buffer(
     let data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
 
-    let logger = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
-        .with_log_interval(TEST_LOG_INTERVAL)
-        .with_stats(vec![stats])
-        .fuse(logger);
+    let builder = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default();
+
+    #[cfg(feature = "interval_logging")]
+    let builder = builder.with_log_interval(TEST_LOG_INTERVAL);
+
+    let logger = builder.with_stats(vec![stats]).fuse(logger);
     (logger, data)
 }
 

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -139,13 +139,10 @@ pub fn create_logger_buffer(
     let data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
 
-    let logger = StatisticsLogger::new(
-        logger,
-        StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
-            .with_log_interval(TEST_LOG_INTERVAL)
-            .with_stats(vec![stats])
-            .fuse(), // LCOV_EXCL_LINE Kcov bug?
-    ); // LCOV_EXCL_LINE Kcov bug?
+    let logger = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
+        .with_log_interval(TEST_LOG_INTERVAL)
+        .with_stats(vec![stats])
+        .fuse(logger);
     (logger, data)
 }
 

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "interval_logging")]
 //! Extlog tests for Stats tracker.
 //!
 
@@ -288,7 +289,8 @@ async fn test_extloggable_set_to() {
         &mut data,
         "counter",
         f64::from(42),
-    ).await;
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -7,7 +7,7 @@ use slog_extlog_derive::ExtLoggable;
 
 use serde::Serialize;
 use slog_extlog::slog_test::*;
-use std::{panic, thread, time};
+use std::{panic, time};
 
 const CRATE_LOG_NAME: &str = "SLOG_STATS_TRACKER_TEST";
 
@@ -184,7 +184,7 @@ fn log_external_grouped(
 }
 
 // Retrieves logs for a given statistic.
-fn get_stat_logs(stat_name: &'static str, mut data: &mut Buffer) -> Vec<serde_json::Value> {
+fn get_stat_logs(stat_name: &str, mut data: &mut Buffer) -> Vec<serde_json::Value> {
     logs_in_range("STATS-1", "STATS-2", &mut data)
         .iter()
         .cloned()
@@ -193,8 +193,8 @@ fn get_stat_logs(stat_name: &'static str, mut data: &mut Buffer) -> Vec<serde_js
 }
 
 // Does the work of checking that we get the expected values in our logs.
-fn check_log_fields(stat_name: &'static str, data: &mut Buffer, metric_type: &str, value: f64) {
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+async fn check_log_fields(stat_name: &str, data: &mut Buffer, metric_type: &str, value: f64) {
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
 
     let logs = get_stat_logs(stat_name, data);
     assert_eq!(logs.len(), 1);
@@ -202,20 +202,20 @@ fn check_log_fields(stat_name: &'static str, data: &mut Buffer, metric_type: &st
     assert_eq!(logs[0]["value"].as_f64(), Some(value));
 }
 
-#[test]
-fn external_logging_works() {
+#[tokio::test]
+async fn external_logging_works() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     log_external_stat(&logger, 234, 1);
 
     // Wait for the stats logs.
-    check_log_fields("test_counter", &mut data, "counter", f64::from(1));
+    check_log_fields("test_counter", &mut data, "counter", f64::from(1)).await;
 
     let logs = logs_in_range("STATS-1", "STATS-2", &mut data);
     assert_eq!(logs.len(), 0);
 }
 
-#[test]
-fn test_extloggable_gauges_with_equality_condition() {
+#[tokio::test]
+async fn test_extloggable_gauges_with_equality_condition() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     log_external_stat(&logger, 5, 76);
@@ -224,11 +224,11 @@ fn test_extloggable_gauges_with_equality_condition() {
     xlog!(logger, SecondExternalLog { floating: 1.34 });
 
     // Wait for the stats logs.
-    check_log_fields("test_gauge", &mut data, "gauge", f64::from(1));
+    check_log_fields("test_gauge", &mut data, "gauge", f64::from(1)).await;
 }
 
-#[test]
-fn test_extloggable_field_gauges() {
+#[tokio::test]
+async fn test_extloggable_field_gauges() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     log_external_stat(&logger, 15, 6);
@@ -238,15 +238,15 @@ fn test_extloggable_field_gauges() {
     info!(logger, "Test log"; "log_id" => "SLOG_STATS_TRACKER_TEST-1", "madeup" => 10);
 
     // Wait for the stats logs.
-    check_log_fields("test_second_gauge", &mut data, "gauge", f64::from(9));
+    check_log_fields("test_second_gauge", &mut data, "gauge", f64::from(9)).await;
 
     log_external_stat(&logger, 2, 0);
 
-    check_log_fields("test_second_gauge", &mut data, "gauge", f64::from(11));
+    check_log_fields("test_second_gauge", &mut data, "gauge", f64::from(11)).await;
 }
 
-#[test]
-fn test_extloggable_strings() {
+#[tokio::test]
+async fn test_extloggable_strings() {
     // For code coverage, test that the `with_params` method works OK.
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     let logger = logger.with_params(o!("global_name" => "foobar"));
@@ -258,11 +258,11 @@ fn test_extloggable_strings() {
         }
     );
 
-    check_log_fields("test_foo_count", &mut data, "counter", f64::from(1));
+    check_log_fields("test_foo_count", &mut data, "counter", f64::from(1)).await;
 }
 
-#[test]
-fn test_extloggable_set_to() {
+#[tokio::test]
+async fn test_extloggable_set_to() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     xlog!(
@@ -288,11 +288,11 @@ fn test_extloggable_set_to() {
         &mut data,
         "counter",
         f64::from(42),
-    );
+    ).await;
 }
 
-#[test]
-fn basic_extloggable_grouped_by_string() {
+#[tokio::test]
+async fn basic_extloggable_grouped_by_string() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     xlog!(
@@ -333,7 +333,7 @@ fn basic_extloggable_grouped_by_string() {
     );
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_grouped_counter", &mut data);
     assert_eq!(logs.len(), 2);
 
@@ -356,8 +356,8 @@ fn basic_extloggable_grouped_by_string() {
     );
 }
 
-#[test]
-fn basic_extloggable_fixed_group() {
+#[tokio::test]
+async fn basic_extloggable_fixed_group() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     xlog!(logger, FixedExternalLog { error: 23 });
@@ -365,7 +365,7 @@ fn basic_extloggable_fixed_group() {
     xlog!(logger, FixedExternalLog { error: 42 });
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_double_grouped", &mut data);
     assert_eq!(logs.len(), 4);
 
@@ -400,8 +400,8 @@ fn basic_extloggable_fixed_group() {
     );
 }
 
-#[test]
-fn basic_extloggable_grouped_by_mixed() {
+#[tokio::test]
+async fn basic_extloggable_grouped_by_mixed() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     log_external_grouped(&logger, "bar".to_string(), 0);
     log_external_grouped(&logger, "foo".to_string(), 2);
@@ -411,7 +411,7 @@ fn basic_extloggable_grouped_by_mixed() {
     log_external_grouped(&logger, "bar".to_string(), 1);
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_double_grouped", &mut data);
     assert_eq!(logs.len(), 5);
 
@@ -452,13 +452,13 @@ fn basic_extloggable_grouped_by_mixed() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_freq() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_freq() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(logger, FifthExternalLog { floating: 2.5 });
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
     assert_eq!(logs.len(), 5);
 
@@ -499,13 +499,13 @@ fn test_extloggable_bucket_counter_freq() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_freq_high_value() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_freq_high_value() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(logger, FifthExternalLog { floating: 10_f32 });
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_freq", &mut data);
     assert_eq!(logs.len(), 5);
 
@@ -546,13 +546,13 @@ fn test_extloggable_bucket_counter_freq_high_value() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_cumul_freq() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_cumul_freq() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(logger, FifthExternalLog { floating: 2.5 });
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_cumul_freq", &mut data);
     assert_eq!(logs.len(), 5);
 
@@ -593,13 +593,13 @@ fn test_extloggable_bucket_counter_cumul_freq() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_cumul_freq_high_value() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_cumul_freq_high_value() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(logger, FifthExternalLog { floating: 8_f32 });
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_cumul_freq", &mut data);
     assert_eq!(logs.len(), 5);
 
@@ -640,8 +640,8 @@ fn test_extloggable_bucket_counter_cumul_freq_high_value() {
     );
 }
 
-#[test]
-fn test_extloggable_buckets_and_repeated_tags() {
+#[tokio::test]
+async fn test_extloggable_buckets_and_repeated_tags() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(
         logger,
@@ -661,7 +661,7 @@ fn test_extloggable_buckets_and_repeated_tags() {
     );
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_grouped_freq", &mut data);
     assert_eq!(logs.len(), 3);
 
@@ -690,8 +690,8 @@ fn test_extloggable_buckets_and_repeated_tags() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_grouped_freq() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_grouped_freq() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(
         logger,
@@ -711,7 +711,7 @@ fn test_extloggable_bucket_counter_grouped_freq() {
     );
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_grouped_freq", &mut data);
     assert_eq!(logs.len(), 6);
 
@@ -758,8 +758,8 @@ fn test_extloggable_bucket_counter_grouped_freq() {
     );
 }
 
-#[test]
-fn test_extloggable_bucket_counter_grouped_cumul_freq() {
+#[tokio::test]
+async fn test_extloggable_bucket_counter_grouped_cumul_freq() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     xlog!(
         logger,
@@ -779,7 +779,7 @@ fn test_extloggable_bucket_counter_grouped_cumul_freq() {
     );
 
     // Wait for the stats logs.
-    thread::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1));
+    tokio::time::sleep(time::Duration::from_secs(TEST_LOG_INTERVAL + 1)).await;
     let logs = get_stat_logs("test_bucket_counter_grouped_cumul_freq", &mut data);
     assert_eq!(logs.len(), 6);
 
@@ -826,8 +826,8 @@ fn test_extloggable_bucket_counter_grouped_cumul_freq() {
     );
 }
 
-#[test]
-fn test_set_slog_logger() {
+#[tokio::test]
+async fn test_set_slog_logger() {
     let (mut logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
 
     // check logging is working
@@ -852,26 +852,26 @@ fn test_set_slog_logger() {
     assert_eq!(logs.len(), 0);
 
     // check that stats were updated anyway
-    check_log_fields("test_counter", &mut data, "counter", f64::from(2));
+    check_log_fields("test_counter", &mut data, "counter", f64::from(2)).await;
 }
 
 // Verify that we can pass loggers across an unwind boundary.
-#[test]
-fn unwind_safety_works() {
+#[tokio::test]
+async fn unwind_safety_works() {
     let (logger, mut data) = create_logger_buffer(SLOG_TEST_STATS);
     let res = panic::catch_unwind(|| {
         log_external_stat(&logger, 234, 1);
     });
     assert!(res.is_ok());
     // Wait for the stats logs.
-    check_log_fields("test_counter", &mut data, "counter", f64::from(1));
+    check_log_fields("test_counter", &mut data, "counter", f64::from(1)).await;
 
     let logs = logs_in_range("STATS-1", "STATS-2", &mut data);
     assert_eq!(logs.len(), 0);
 }
 
-#[test]
-fn multiple_stats_defns() {
+#[tokio::test]
+async fn multiple_stats_defns() {
     #[derive(ExtLoggable, Clone, Serialize)]
     #[LogDetails(Id = "100", Text = "Something special happened", Level = "Info")]
     #[StatTrigger(StatName = "test_special_counter", Action = "Incr", Value = "1")]
@@ -887,16 +887,13 @@ fn multiple_stats_defns() {
     let mut data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
 
-    let logger = StatisticsLogger::new(
-        logger,
-        StatsConfigBuilder::<DefaultStatisticsLogFormatter>::new()
-            .with_log_interval(TEST_LOG_INTERVAL)
-            .with_stats(vec![SLOG_TEST_STATS, SLOG_EXTRA_STATS])
-            .fuse(), // LCOV_EXCL_LINE Kcov bug?
-    ); // LCOV_EXCL_LINE Kcov bug?
+    let logger = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
+        .with_log_interval(TEST_LOG_INTERVAL)
+        .with_stats(vec![SLOG_TEST_STATS, SLOG_EXTRA_STATS])
+        .fuse(logger);
 
     xlog!(logger, SpecialLog);
     log_external_stat(&logger, 246, 7);
-    check_log_fields("test_counter", &mut data, "counter", f64::from(1));
-    check_log_fields("test_special_counter", &mut data, "counter", f64::from(1));
+    check_log_fields("test_counter", &mut data, "counter", f64::from(1)).await;
+    check_log_fields("test_special_counter", &mut data, "counter", f64::from(1)).await;
 }

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -124,16 +124,16 @@ struct GroupBucketCounterLog {
 }
 //LCOV_EXCL_STOP
 
-#[test]
-fn request_with_no_stats() {
-    let (logger, _) = create_logger_buffer(EMPTY_STATS);
+#[tokio::test]
+async fn request_with_no_stats() {
+    let (logger, _) = create_logger_buffer(&[]);
     let stats = logger.get_stats();
 
     assert_eq!(stats.len(), 0);
 }
 
-#[test]
-fn request_for_single_counter() {
+#[tokio::test]
+async fn request_for_single_counter() {
     static STATS: StatDefinitions = &[&test_counter];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -154,8 +154,8 @@ fn request_for_single_counter() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_gauge() {
+#[tokio::test]
+async fn request_for_single_gauge() {
     static STATS: StatDefinitions = &[&test_gauge];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -176,8 +176,8 @@ fn request_for_single_gauge() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_multiple_metrics() {
+#[tokio::test]
+async fn request_for_multiple_metrics() {
     static STATS: StatDefinitions = &[&test_counter, &test_gauge];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -211,8 +211,8 @@ fn request_for_multiple_metrics() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_updated_metrics() {
+#[tokio::test]
+async fn request_for_updated_metrics() {
     static STATS: StatDefinitions = &[&test_counter, &test_gauge];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -250,8 +250,8 @@ fn request_for_updated_metrics() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_counter_with_groups_but_no_values() {
+#[tokio::test]
+async fn request_for_single_counter_with_groups_but_no_values() {
     static STATS: StatDefinitions = &[&test_grouped_counter];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -268,8 +268,8 @@ fn request_for_single_counter_with_groups_but_no_values() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_gauge_with_groups_but_no_values() {
+#[tokio::test]
+async fn request_for_single_gauge_with_groups_but_no_values() {
     static STATS: StatDefinitions = &[&test_grouped_gauge];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -286,8 +286,8 @@ fn request_for_single_gauge_with_groups_but_no_values() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_counter_with_groups_and_one_value() {
+#[tokio::test]
+async fn request_for_single_counter_with_groups_and_one_value() {
     static STATS: StatDefinitions = &[&test_grouped_counter];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -317,8 +317,8 @@ fn request_for_single_counter_with_groups_and_one_value() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_gauge_with_groups_and_one_value() {
+#[tokio::test]
+async fn request_for_single_gauge_with_groups_and_one_value() {
     static STATS: StatDefinitions = &[&test_grouped_gauge];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -348,8 +348,8 @@ fn request_for_single_gauge_with_groups_and_one_value() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_single_counter_with_groups_and_two_values() {
+#[tokio::test]
+async fn request_for_single_counter_with_groups_and_two_values() {
     static STATS: StatDefinitions = &[&test_grouped_counter];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -395,8 +395,8 @@ fn request_for_single_counter_with_groups_and_two_values() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_bucket_counter_freq() {
+#[tokio::test]
+async fn request_for_bucket_counter_freq() {
     static STATS: StatDefinitions = &[&test_bucket_counter_freq];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -434,8 +434,8 @@ fn request_for_bucket_counter_freq() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_bucket_counter_freq_one_value() {
+#[tokio::test]
+async fn request_for_bucket_counter_freq_one_value() {
     static STATS: StatDefinitions = &[&test_bucket_counter_freq];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -476,8 +476,8 @@ fn request_for_bucket_counter_freq_one_value() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_bucket_counter_cumul_freq() {
+#[tokio::test]
+async fn request_for_bucket_counter_cumul_freq() {
     static STATS: StatDefinitions = &[&test_bucket_counter_cumul_freq];
     let (logger, _) = create_logger_buffer(STATS);
     let stats = logger.get_stats();
@@ -519,8 +519,8 @@ fn request_for_bucket_counter_cumul_freq() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_bucket_counter_with_groups_and_two_values() {
+#[tokio::test]
+async fn request_for_bucket_counter_with_groups_and_two_values() {
     static STATS: StatDefinitions = &[&test_group_bucket_counter];
     let (logger, _) = create_logger_buffer(STATS);
 
@@ -588,8 +588,8 @@ fn request_for_bucket_counter_with_groups_and_two_values() {
     ); // LCOV_EXCL_LINE Kcov bug?
 }
 
-#[test]
-fn request_for_many_metrics() {
+#[tokio::test]
+async fn request_for_many_metrics() {
     let (logger, _) = create_logger_buffer(ALL_STATS);
 
     xlog!(logger, CounterUpdateLog { delta: 1 });


### PR DESCRIPTION
Builds on top of @dimbleby's MR to change to tokio 1.0 (#18).

Changelog snippet:

- `StatisticsLogger` creation API has changed:
    - Removed `StatsConfig` and `StatsConfigBuilder`
    - Added `StatsLoggerBuilder` with `fuse(logger)` to create the `StatisticsLogger`
    - Creating a `StatisticsLogger` must be done within a `tokio v1.0` runtime if the interval logging is enabled

I've updated all the tests/benches to use `tokio::test`/`tokio::main` to ensure a runtime exists when creating the logger (except in one case which is testing without interval logging).