### PR TITLE
Hide derive re-exports behind a feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ script:
   if git log ${DCO_SIGNING_BASE_COMMIT}.. --grep "^signed-off-by: .\+@.\+" --regexp-ignore-case --invert-grep --no-merges | grep ^ ;
   then echo '**One or more commits are not signed off!' ; /bin/false ; fi
 - cargo clippy --all-targets --all-features --all -- -D warnings
-- cargo test --all
+- cargo clippy --all-targets --no-default-features --all -- -D warnings
+- cargo test --all --all-features
+- cargo test --all --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,33 +17,28 @@ name = "stats"
 [dependencies]
 iobuffer = "0.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+serde_json = "1.0"
+slog = { version = "2.4", features = [ "nested-values" ] }
+slog-json = { version = "2.1", features = [ "nested-values" ] }
 
 # Used by the interval_logging feature
-tokio = { version = "1", features = ["rt", "time"], optional = true }
+tokio = { version = "1", features = [ "rt", "time" ], optional = true }
 
 # The version here is pinned hard to the same version as this crate
 # this is to allow the derive <-> extlog crate APIs to stay perfectly in sync,
-# allowing breaking changes that only affect each other to be elided
-[dependencies.slog-extlog-derive]
-version = "=6.0.1"
-path = "slog-extlog-derive"
-
-[dependencies.slog]
-features = ["nested-values"]
-version = "2.4"
-
-[dependencies.slog-json]
-features = ["nested-values"]
-version = "2.1"
+# allowing breaking changes that only affect the interface between these crates
+# to be elided downstream
+slog-extlog-derive = { version = "=6.0.1", path = "slog-extlog-derive", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.5"
 erased-serde = "0.3"
 tokio = { version = "1", features = [ "macros", "rt-multi-thread", "time" ] }
+slog-extlog-derive = { version = "=6.0.1", path = "slog-extlog-derive" }
 
 [features]
 interval_logging = [ "tokio" ]
+derive = [ "slog-extlog-derive" ]
 
 [workspace]
-members = ["slog-extlog-derive"]
+members = [ "slog-extlog-derive" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,4 +231,5 @@ macro_rules! impl_value_wrapper {
 }
 
 // Re-export the derive macros to ensure that version compatibility is preserved
+#[cfg(feature = "derive")]
 pub use slog_extlog_derive::{ExtLoggable, SlogValue};

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -37,7 +37,6 @@ use std::sync::RwLock;
 #[cfg(feature = "interval_logging")]
 use std::time::Duration;
 
-use serde::Serialize;
 use slog::info;
 
 //////////////////////////////////////////////////////
@@ -232,7 +231,7 @@ pub enum ChangeType {
 }
 
 /// Used to represent the upper limit of a bucket.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, PartialOrd, Eq, Ord)]
 pub enum BucketLimit {
     /// A numerical upper limit.
     Num(i64),
@@ -264,7 +263,7 @@ impl fmt::Display for BucketLimit {
 }
 
 /// A set of numerical buckets together with a method for sorting values into them.
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, PartialEq)]
 pub struct Buckets {
     /// The method to use to sort values into buckets.
     pub method: BucketMethod,
@@ -327,7 +326,7 @@ impl Buckets {
 }
 
 /// Used to determine which buckets to update when a BucketCounter stat is updated
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq)]
 pub enum BucketMethod {
     /// When a value is recorded, only update the bucket it lands in
     Freq,
@@ -336,7 +335,7 @@ pub enum BucketMethod {
 }
 
 /// Types of statistics.  Automatically determined from the `StatDefinition`.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq)]
 pub enum StatType {
     /// A counter - a value that only increments.
     Counter,

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -3,6 +3,10 @@
 use serde::Serialize;
 
 use slog_extlog::{define_stats, xlog};
+
+#[cfg(feature = "derive")]
+use slog_extlog::ExtLoggable;
+#[cfg(not(feature = "derive"))]
 use slog_extlog_derive::ExtLoggable;
 
 use slog_extlog::slog_test::*;


### PR DESCRIPTION
I've worked out why serde does this, if you don't need the derive macros, you can avoid compiling syn/quote which take ages.