### PR TITLE
Remove type bounds from StatsTracker and StatisticsLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-
-### Added
+- Change `StatsTracker` and `StatisticsLogger` to not be bound by <T>
+  - Breaking change: users must now pass the formatter as a type parameter
+    to the `fuse()` method of the StatsLoggerBuilder.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- Change `StatsTracker` and `StatisticsLogger` to not be bound by <T>
-  - Breaking change: users must now pass the formatter as a type parameter
-    to the `fuse()` method of the StatsLoggerBuilder.
+- Change `StatsTracker`, `StatsLoggerBuilder` and `StatisticsLogger` to not be bound by `<T>`
+  - Breaking change: `StatsLoggerBuilder` loses `with_log_interval()` and gains `fuse_with_log_interval<T>`,
+    where `<T>` is a `StatisticsLogFormatter`. This method is only accessible with
+    the `interval_logging` feature.
+  - Breaking change: `StatsTracker::log_all()` now requires a `<T: StatisticsLogFormatter>` bound
+    when called.
 
 ### Fixed
 

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -140,7 +140,7 @@
 //!   let slog_logger = slog::Logger::root(slog::Discard, o!());
 //!   let logger = stats::StatsLoggerBuilder::default()
 //!       .with_stats(vec![FOO_STATS])
-//!       .fuse::<stats::DefaultStatisticsLogFormatter>(slog_logger);
+//!       .fuse(slog_logger);
 //!
 //!   // Now all logs of `FooReqRcvd` will increment the `FooNonEmptyCount` and
 //!   // `FooTotalBytesByUser` stats...

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -138,9 +138,9 @@
 //! async fn main() {
 //!   // Create the logger using whatever log format required.
 //!   let slog_logger = slog::Logger::root(slog::Discard, o!());
-//!   let logger: slog_extlog::DefaultLogger = stats::StatsLoggerBuilder::default()
+//!   let logger = stats::StatsLoggerBuilder::default()
 //!       .with_stats(vec![FOO_STATS])
-//!       .fuse(slog_logger);
+//!       .fuse::<stats::DefaultStatisticsLogFormatter>(slog_logger);
 //!
 //!   // Now all logs of `FooReqRcvd` will increment the `FooNonEmptyCount` and
 //!   // `FooTotalBytesByUser` stats...
@@ -577,8 +577,7 @@ fn impl_loggable(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
             for #name<#(#lifetimes_2,)* #(#tys_2),*>
         #(where #tys_3: #(#bounds + )* slog::Value),*{
 
-            fn ext_log<T>(&self, logger: &slog_extlog::stats::StatisticsLogger<T>)
-            where T: slog_extlog::stats::StatisticsLogFormatter + Send + Sync + 'static {
+            fn ext_log(&self, logger: &slog_extlog::stats::StatisticsLogger) {
                 logger.update_stats(self);
                 // Use a `FnValue` for the log ID so the format string is allcoated only if the log
                 // is actually written.  dieally, we'd like this to be compile-time allocated but

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -5,6 +5,7 @@
 
 use serde::Serialize;
 use slog::o;
+use slog_extlog::stats::DefaultStatisticsLogFormatter;
 use slog_extlog::xlog;
 use slog_extlog_derive::{ExtLoggable, SlogValue};
 
@@ -18,7 +19,7 @@ const CRATE_LOG_NAME: &str = "SLOGTST";
 fn create_logger(testname: &'static str) -> (DefaultLogger, iobuffer::IoBuffer) {
     let data = iobuffer::IoBuffer::new();
     let logger = slog_test::new_test_logger(data.clone()).new(o!("testname" => testname));
-    let logger = StatsLoggerBuilder::default().fuse(logger);
+    let logger = StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(logger);
     (logger, data)
 }
 
@@ -72,7 +73,8 @@ async fn test_derived_structs() {
         user: "Bob".to_string(),
         count: 2,
     }));
-    let foo_logger: DefaultLogger = StatsLoggerBuilder::default().fuse(foo_logger);
+    let foo_logger =
+        StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(foo_logger);
 
     xlog!(foo_logger, FooRspRcvd(FooRspType::Ok, "Success"));
     let logs = slog_test::read_json_values(&mut data);

--- a/slog-extlog-derive/tests/loggable.rs
+++ b/slog-extlog-derive/tests/loggable.rs
@@ -5,7 +5,6 @@
 
 use serde::Serialize;
 use slog::o;
-use slog_extlog::stats::DefaultStatisticsLogFormatter;
 use slog_extlog::xlog;
 use slog_extlog_derive::{ExtLoggable, SlogValue};
 
@@ -19,7 +18,7 @@ const CRATE_LOG_NAME: &str = "SLOGTST";
 fn create_logger(testname: &'static str) -> (DefaultLogger, iobuffer::IoBuffer) {
     let data = iobuffer::IoBuffer::new();
     let logger = slog_test::new_test_logger(data.clone()).new(o!("testname" => testname));
-    let logger = StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(logger);
+    let logger = StatsLoggerBuilder::default().fuse(logger);
     (logger, data)
 }
 
@@ -73,8 +72,7 @@ async fn test_derived_structs() {
         user: "Bob".to_string(),
         count: 2,
     }));
-    let foo_logger =
-        StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(foo_logger);
+    let foo_logger = StatsLoggerBuilder::default().fuse(foo_logger);
 
     xlog!(foo_logger, FooRspRcvd(FooRspType::Ok, "Success"));
     let logs = slog_test::read_json_values(&mut data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!         id: "123456789".to_string(),
 //!         method: FooMethod::POST,
 //!     }));
-//!     let foo_logger = StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(logger);
+//!     let foo_logger = StatsLoggerBuilder::default().fuse(logger);
 //!
 //!     // Now make some logs...
 //!     xlog!(foo_logger, FooReqRcvd);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! ```
 //! use serde::Serialize;
-//! use slog_extlog::{DefaultLogger, stats::StatsLoggerBuilder, define_stats, xlog};
+//! use slog_extlog::{stats::DefaultStatisticsLogFormatter, stats::StatsLoggerBuilder, define_stats, xlog};
 //! use slog_extlog_derive::{ExtLoggable, SlogValue};
 //!
 //! use slog::{Drain, debug, info, o};
@@ -123,7 +123,7 @@
 //!         id: "123456789".to_string(),
 //!         method: FooMethod::POST,
 //!     }));
-//!     let foo_logger: DefaultLogger = StatsLoggerBuilder::default().fuse(logger);
+//!     let foo_logger = StatsLoggerBuilder::default().fuse::<DefaultStatisticsLogFormatter>(logger);
 //!
 //!     // Now make some logs...
 //!     xlog!(foo_logger, FooReqRcvd);
@@ -160,7 +160,7 @@ impl<T> SlogValueDerivable for T where T: std::fmt::Debug + Clone + serde::Seria
 {}
 
 /// The default logger type.
-pub type DefaultLogger = stats::StatisticsLogger<stats::DefaultStatisticsLogFormatter>;
+pub type DefaultLogger = stats::StatisticsLogger;
 
 /// An object that can be logged.
 ///
@@ -170,9 +170,7 @@ pub trait ExtLoggable: slog::Value {
     /// Log this object with the provided `Logger`.
     ///
     /// Do not call directly - use [`xlog!`](macro.xlog.html) instead.
-    fn ext_log<T>(&self, logger: &stats::StatisticsLogger<T>)
-    where
-        T: stats::StatisticsLogFormatter + Send + Sync + 'static;
+    fn ext_log(&self, logger: &stats::StatisticsLogger);
 }
 
 /// Log an external log through an `slog::Logger`.

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -133,18 +133,18 @@ pub static TEST_LOG_INTERVAL: u64 = 5;
 ///
 /// Creates a logger using the provided statistics and buffer so we can easily
 /// view the generated logs.
-pub fn create_logger_buffer(
-    stats: StatDefinitions,
-) -> (StatisticsLogger<DefaultStatisticsLogFormatter>, Buffer) {
+pub fn create_logger_buffer(stats: StatDefinitions) -> (StatisticsLogger, Buffer) {
     let data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
 
-    let builder = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default();
+    let builder = StatsLoggerBuilder::default();
 
     #[cfg(feature = "interval_logging")]
     let builder = builder.with_log_interval(TEST_LOG_INTERVAL);
 
-    let logger = builder.with_stats(vec![stats]).fuse(logger);
+    let logger = builder
+        .with_stats(vec![stats])
+        .fuse::<DefaultStatisticsLogFormatter>(logger);
     (logger, data)
 }
 

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -129,6 +129,20 @@ pub fn assert_json_matches(actual: &serde_json::Value, expected: &serde_json::Va
 /// A default logging interval for tests, short so UTs run faster.
 pub static TEST_LOG_INTERVAL: u64 = 5;
 
+#[cfg(feature = "interval_logging")]
+fn new_stats_logger(stats: StatDefinitions, logger: slog::Logger) -> StatisticsLogger {
+    let builder = StatsLoggerBuilder::default();
+    builder
+        .with_stats(vec![stats])
+        .fuse_with_log_interval::<DefaultStatisticsLogFormatter>(TEST_LOG_INTERVAL, logger)
+}
+
+#[cfg(not(feature = "interval_logging"))]
+fn new_stats_logger(stats: StatDefinitions, logger: slog::Logger) -> StatisticsLogger {
+    let builder = StatsLoggerBuilder::default();
+    builder.with_stats(vec![stats]).fuse(logger)
+}
+
 /// Common setup function.
 ///
 /// Creates a logger using the provided statistics and buffer so we can easily
@@ -136,16 +150,8 @@ pub static TEST_LOG_INTERVAL: u64 = 5;
 pub fn create_logger_buffer(stats: StatDefinitions) -> (StatisticsLogger, Buffer) {
     let data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
-
-    let builder = StatsLoggerBuilder::default();
-
-    #[cfg(feature = "interval_logging")]
-    let builder = builder.with_log_interval(TEST_LOG_INTERVAL);
-
-    let logger = builder
-        .with_stats(vec![stats])
-        .fuse::<DefaultStatisticsLogFormatter>(logger);
-    (logger, data)
+    let stats_logger = new_stats_logger(stats, logger);
+    (stats_logger, data)
 }
 
 /// An expected statistic helper method.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -27,7 +27,6 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::marker::PhantomData;
 use std::ops::Deref;
 use std::panic::RefUnwindSafe;
 use std::sync::atomic::{AtomicIsize, Ordering};
@@ -367,34 +366,15 @@ impl slog::Value for StatType {
 
 /// An object that tracks statistics and can be asked to log them
 // LCOV_EXCL_START not interesting to track automatic derive coverage
-#[derive(Debug)]
-pub struct StatsTracker<T: StatisticsLogFormatter> {
+#[derive(Debug, Default)]
+pub struct StatsTracker {
     // The list of statistics, mapping from stat name to value.
     stats: HashMap<&'static str, Stat>,
-
-    // The callback to make for logging the statistic.  This is a marker type so store it
-    // as phantom.
-    stat_formatter: PhantomData<T>,
 }
 // LCOV_EXCL_STOP
 
-impl<T> Default for StatsTracker<T>
-where
-    T: StatisticsLogFormatter,
-{
-    fn default() -> Self {
-        StatsTracker {
-            stats: HashMap::new(),
-            stat_formatter: PhantomData,
-        }
-    }
-}
-
-impl<T> StatsTracker<T>
-where
-    T: StatisticsLogFormatter,
-{
-    /// Create a new tracker with the given formatter.
+impl StatsTracker {
+    /// Create a new tracker.
     pub fn new() -> Self {
         Default::default()
     }
@@ -435,7 +415,7 @@ where
     /// Log all statistics.
     ///
     /// This function is usually just called on a timer by the logger directly.
-    pub fn log_all(&self, logger: &StatisticsLogger<T>) {
+    pub fn log_all<T: StatisticsLogFormatter>(&self, logger: &StatisticsLogger) {
         for stat in self.stats.values() {
             // Log all the grouped and bucketed values.
             let outputs = stat.get_tagged_vals();
@@ -501,17 +481,14 @@ pub type StatDefinitions = &'static [&'static (dyn StatDefinition + Sync + RefUn
 ///
 /// let full_stats = vec![MY_STATS];
 /// let logger = slog::Logger::root(slog::Discard, slog::o!());
-/// let stats = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
+/// let stats = StatsLoggerBuilder::default()
 ///     .with_stats(full_stats)
-///     .fuse(logger);
+///     .fuse::<DefaultStatisticsLogFormatter>(logger);
 ///
 /// # }
 /// ```
-#[derive(Debug)]
-pub struct StatsLoggerBuilder<T>
-where
-    T: StatisticsLogFormatter,
-{
+#[derive(Debug, Default)]
+pub struct StatsLoggerBuilder {
     /// The period, in seconds, to log the generated metrics into the log stream.  One log will be
     /// generated for each metric value.  A value of `None` indicates stats should never be logged.
     /// Defaults to `None` (no interval logging).
@@ -520,25 +497,9 @@ where
     /// The list of statistics to track.  This MUST be created using the
     /// [`define_stats`](../macro.define_stats.html) macro.
     pub stats: Vec<StatDefinitions>,
-    /// An object that handles formatting the individual statistic values into a log.
-    pub stat_formatter: PhantomData<T>,
 }
 
-impl<T> Default for StatsLoggerBuilder<T>
-where
-    T: StatisticsLogFormatter,
-{
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "interval_logging")]
-            interval_secs: None,
-            stats: vec![],
-            stat_formatter: PhantomData,
-        }
-    }
-}
-
-impl<T: StatisticsLogFormatter> StatsLoggerBuilder<T> {
+impl StatsLoggerBuilder {
     /// Set the list of statistics to track.
     pub fn with_stats(mut self, stats: Vec<StatDefinitions>) -> Self {
         self.stats = stats;
@@ -553,7 +514,7 @@ impl<T: StatisticsLogFormatter> StatsLoggerBuilder<T> {
     }
 
     /// Construct the StatisticsLogger - this will start the interval logging if requested.
-    pub fn fuse(self, logger: slog::Logger) -> StatisticsLogger<T> {
+    pub fn fuse<T: StatisticsLogFormatter>(self, logger: slog::Logger) -> StatisticsLogger {
         let mut tracker = StatsTracker::new();
         for set in self.stats {
             for s in set {
@@ -586,7 +547,7 @@ impl<T: StatisticsLogFormatter> StatsLoggerBuilder<T> {
 
                     loop {
                         interval.tick().await;
-                        timer_full_logger.tracker.log_all(&timer_full_logger);
+                        timer_full_logger.tracker.log_all::<T>(&timer_full_logger);
                     }
                 });
             }
@@ -623,7 +584,7 @@ pub static DEFAULT_LOG_ID: &str = "STATS-1";
 
 impl StatisticsLogFormatter for DefaultStatisticsLogFormatter {
     /// The formatting callback.  This default implementation just logs each field.
-    fn log_stat(logger: &StatisticsLogger<Self>, stat: &StatLogData<'_>)
+    fn log_stat(logger: &StatisticsLogger, stat: &StatLogData<'_>)
     where
         Self: Sized,
     {
@@ -650,7 +611,7 @@ pub trait StatisticsLogFormatter: Sync + Send + 'static {
     /// The `DefaultStatisticsLogFormatter` provides a basic format, or users can override the
     /// format of the generated logs by providing an object that implements this trait in the
     /// `StatsConfig`.
-    fn log_stat(logger: &StatisticsLogger<Self>, stat: &StatLogData<'_>)
+    fn log_stat(logger: &StatisticsLogger, stat: &StatLogData<'_>)
     where
         Self: Sized;
 }
@@ -658,38 +619,22 @@ pub trait StatisticsLogFormatter: Sync + Send + 'static {
 /// A logger with statistics tracking.
 ///
 /// This should only be created through the `new` method.
-#[derive(Debug)]
-pub struct StatisticsLogger<T: StatisticsLogFormatter> {
+#[derive(Debug, Clone)]
+pub struct StatisticsLogger {
     /// The logger that receives the logs.
     logger: slog::Logger,
     /// The stats tracker.
-    tracker: Arc<StatsTracker<T>>,
+    tracker: Arc<StatsTracker>,
 }
 
-// Manually impl clone because the automatically derived type requires that `T:Clone`,
-// which isn't needed.
-//
-// See https://github.com/rust-lang/rust/issues/26925 for details.
-impl<T: StatisticsLogFormatter> Clone for StatisticsLogger<T> {
-    fn clone(&self) -> Self {
-        StatisticsLogger {
-            logger: self.logger.clone(),
-            tracker: self.tracker.clone(),
-        } // LCOV_EXCL_LINE Kcov bug
-    }
-}
-
-impl<T: StatisticsLogFormatter> Deref for StatisticsLogger<T> {
+impl Deref for StatisticsLogger {
     type Target = slog::Logger;
     fn deref(&self) -> &Self::Target {
         &self.logger
     }
 }
 
-impl<T> StatisticsLogger<T>
-where
-    T: StatisticsLogFormatter + Send + Sync + 'static,
-{
+impl StatisticsLogger {
     /// Build a child logger with new parameters.
     ///
     /// This is essentially a wrapper around `slog::Logger::new()`.
@@ -1231,7 +1176,7 @@ mod tests {
     #[allow(dead_code)]
     struct DummyNonCloneFormatter;
     impl StatisticsLogFormatter for DummyNonCloneFormatter {
-        fn log_stat(_logger: &StatisticsLogger<Self>, _stat: &StatLogData<'_>)
+        fn log_stat(_logger: &StatisticsLogger, _stat: &StatLogData<'_>)
         where
             Self: Sized,
         {
@@ -1241,8 +1186,9 @@ mod tests {
     #[test]
     // Check that loggers can be cloned even if the formatter can't.
     fn check_clone() {
-        let builder = StatsLoggerBuilder::<DummyNonCloneFormatter>::default();
-        let logger = builder.fuse(slog::Logger::root(slog::Discard, slog::o!()));
+        let builder = StatsLoggerBuilder::default();
+        let logger =
+            builder.fuse::<DummyNonCloneFormatter>(slog::Logger::root(slog::Discard, slog::o!()));
         fn is_clone<T: Clone>(_: &T) {}
         is_clone(&logger);
     }

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -882,9 +882,8 @@ async fn multiple_stats_defns() {
     let logger = new_test_logger(data.clone());
 
     let logger = StatsLoggerBuilder::default()
-        .with_log_interval(TEST_LOG_INTERVAL)
         .with_stats(vec![SLOG_TEST_STATS, SLOG_EXTRA_STATS])
-        .fuse::<DefaultStatisticsLogFormatter>(logger);
+        .fuse_with_log_interval::<DefaultStatisticsLogFormatter>(TEST_LOG_INTERVAL, logger);
 
     xlog!(logger, SpecialLog);
     log_external_stat(&logger, 246, 7);

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -160,20 +160,12 @@ struct FixedExternalLog {
 // LCOV_EXCL_STOP
 
 // Shortcut for a standard external log of the first struct with given values.
-fn log_external_stat(
-    logger: &StatisticsLogger<DefaultStatisticsLogFormatter>,
-    bytes: u32,
-    unbytes: i8,
-) {
+fn log_external_stat(logger: &StatisticsLogger, bytes: u32, unbytes: i8) {
     xlog!(logger, ExternalLog { bytes, unbytes });
 }
 
 // Shortcut for a standard external log of the fourth struct with given values.
-fn log_external_grouped(
-    logger: &StatisticsLogger<DefaultStatisticsLogFormatter>,
-    name: String,
-    error: u8,
-) {
+fn log_external_grouped(logger: &StatisticsLogger, name: String, error: u8) {
     xlog!(
         logger,
         FourthExternalLog {
@@ -889,10 +881,10 @@ async fn multiple_stats_defns() {
     let mut data = iobuffer::IoBuffer::new();
     let logger = new_test_logger(data.clone());
 
-    let logger = StatsLoggerBuilder::<DefaultStatisticsLogFormatter>::default()
+    let logger = StatsLoggerBuilder::default()
         .with_log_interval(TEST_LOG_INTERVAL)
         .with_stats(vec![SLOG_TEST_STATS, SLOG_EXTRA_STATS])
-        .fuse(logger);
+        .fuse::<DefaultStatisticsLogFormatter>(logger);
 
     xlog!(logger, SpecialLog);
     log_external_stat(&logger, 246, 7);


### PR DESCRIPTION
- Change `StatsTracker`, `StatsLoggerBuilder` and `StatisticsLogger` to not be bound by `<T>`
  - Breaking change: `StatsLoggerBuilder` loses `with_log_interval()` and gains `fuse_with_log_interval<T>`,
    where `<T>` is a `StatisticsLogFormatter`. This method is only accessible with
    the `interval_logging` feature.

Signed-off-by: Max Dymond <max.dymond@microsoft.com>

---

This MR removes the type bounds on StatsTracker and StatisticsLogger so they are not type-bound by the Formatter type. The `fuse()` method is the only thing that requires a type bound (and even then only for interval logging).