### PR TITLE
Re-export `erased_serde` from `slog_extlog`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "stats"
 [dependencies]
 iobuffer = "0.2"
 serde = { version = "1.0", features = ["derive"] }
+erased-serde = "0.3"
 serde_json = "1.0"
 slog = { version = "2.4", features = [ "nested-values" ] }
 slog-json = { version = "2.1", features = [ "nested-values" ] }
@@ -32,7 +33,6 @@ slog-extlog-derive = { version = "=8.0.0", path = "slog-extlog-derive", optional
 
 [dev-dependencies]
 bencher = "0.1.5"
-erased-serde = "0.3"
 tokio = { version = "1", features = [ "macros", "rt-multi-thread", "time" ] }
 slog-extlog-derive = { version = "=8.0.0", path = "slog-extlog-derive" }
 

--- a/slog-extlog-derive/Cargo.toml
+++ b/slog-extlog-derive/Cargo.toml
@@ -20,7 +20,6 @@ quote = "1.0.7"
 proc-macro = true
 
 [dev-dependencies]
-erased-serde = "0.3"
 iobuffer = "0.2"
 serde =  { version = "1.0", features = ["derive"] }
 # Cargo doesn't let you publish crates with circular dev dependencies,

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -261,7 +261,7 @@ fn impl_value_traits(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
             #(where #tys_3: #(#bounds + )* serde::Serialize + slog::Value),*  {
 
             /// Convert into a serde object.
-            fn as_serde(&self) -> &erased_serde::Serialize {
+            fn as_serde(&self) -> &slog_extlog::erased_serde::Serialize {
                 self
             }
 

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -365,9 +365,6 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
         .map(|t| &t.condition_body)
         .collect::<Vec<_>>();
 
-    // Build up the input match statements value for the `change` method.
-    let stat_ids_change = stat_ids_cond.clone();
-
     // Build up the return values for those match statements.
     let stat_changes = triggers
         .iter()
@@ -465,7 +462,7 @@ fn impl_stats_trigger(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                       stat_id: &slog_extlog::stats::StatDefinitionTagged) ->
                       Option<slog_extlog::stats::ChangeType> {
                 match stat_id.defn.name() {
-                    #(#stat_ids_change => #stat_changes,)*
+                    #(#stat_ids_cond => #stat_changes,)*
                     s => panic!("Change requested for unknown stat {}", s)
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,9 @@
 
 // Copyright 2017 Metaswitch Networks
 
+/// Re-export erased_serde since the derive crate references it
+pub use erased_serde;
+
 // Statistics handling
 pub mod stats;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -292,7 +292,7 @@ impl Buckets {
                 .iter()
                 .enumerate()
                 .filter(|(_, limit)| match limit {
-                    BucketLimit::Num(b) => (value <= *b as f64),
+                    BucketLimit::Num(b) => value <= *b as f64,
                     BucketLimit::Unbounded => true,
                 })
                 .map(|(i, _)| i)
@@ -761,11 +761,11 @@ impl StatTypeData {
     }
 
     /// Get all the tags for this stat as a vector of `(name, value)` tuples.
-    fn get_tag_pairs<'a, 'b, 'c>(
-        &'a self,
-        tag_values: &'b str,
-        defn: &'c dyn StatDefinition,
-    ) -> Option<Vec<(&'static str, &'b str)>> {
+    fn get_tag_pairs<'a>(
+        &self,
+        tag_values: &'a str,
+        defn: &dyn StatDefinition,
+    ) -> Option<Vec<(&'static str, &'a str)>> {
         if let StatTypeData::BucketCounter(ref bucket_counter_data) = self {
             Some(bucket_counter_data.get_tag_pairs(tag_values, defn))
         } else {
@@ -875,11 +875,11 @@ impl BucketCounterData {
     }
 
     /// Get all the tags for this stat as a vector of `(name, value)` tuples.
-    fn get_tag_pairs<'a, 'b, 'c>(
-        &'a self,
-        tag_values: &'b str,
-        defn: &'c dyn StatDefinition,
-    ) -> Vec<(&'static str, &'b str)> {
+    fn get_tag_pairs<'a>(
+        &self,
+        tag_values: &'a str,
+        defn: &dyn StatDefinition,
+    ) -> Vec<(&'static str, &'a str)> {
         let mut tag_names = defn.group_by();
         // Add the bucket label name as an additional tag name.
         tag_names.push(self.buckets.label_name);
@@ -987,7 +987,7 @@ struct Stat {
 
 impl Stat {
     // Get all the tags for this stat as a vector of `(name, value)` tuples.
-    fn get_tag_pairs<'a, 'b>(&'a self, tag_values: &'b str) -> Vec<(&'static str, &'b str)> {
+    fn get_tag_pairs<'a>(&self, tag_values: &'a str) -> Vec<(&'static str, &'a str)> {
         // if the stat type has its own `get_tag_pairs` method use that, otherwise
         // use the default.
         self.stat_type_data


### PR DESCRIPTION
(and use the reexported name in `slog-extlog-derive`)

This means consumers of the derive crate don't need to also depend on `erased_serde` (unless they want to).  An alternative would be for `slog` to re-export `erased_serde` and the derive names it from there (or `slog_extlog` re-re-exports it?)