### PR TITLE
Apply clippy suggestions from current stable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,19 +3,11 @@
 [build]
 
 rustflags = [
-
     "-W", "missing_docs",  # detects missing documentation for public members
-
     "-W", "trivial_casts",  # detects trivial casts which could be removed
-
     "-W", "trivial_numeric_casts",  # detects trivial casts of numeric types which could be removed
-
     "-W", "unsafe_code",  # usage of `unsafe` code
-
     "-W", "unused_qualifications",  # detects unnecessarily qualified names
-
     "-W", "unused_extern_crates",  # extern crates that are never used
-
     "-W", "unused_import_braces",  # unnecessary braces around an imported item
-
-    ]
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,15 +11,13 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build (all features)
-      run: cargo clippy --verbose --all-targets --all-features --all -- -D warnings
+      run: cargo clippy --verbose --all-targets --all-features --all -- -D warnings -A clippy::duplicated-attributes
     - name: Build (no features)
-      run: cargo clippy --verbose --all-targets --no-default-features --all -- -D warnings
+      run: cargo clippy --verbose --all-targets --no-default-features --all -- -D warnings -A clippy::duplicated-attributes
     - name: Run tests (all features)
       run: cargo test --verbose --all --all-features
     - name: Run tests (no features)

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -93,7 +93,7 @@ fn gauge_incr_decr_log(bench: &mut Bencher) {
     let logger = setup_logger();
     bench.iter(|| {
         xlog!(logger, FooIncrLog { foo: 42 });
-        xlog!(logger, FooIncrLog { foo: 27 });
+        xlog!(logger, FooDecrLog { foo: 27 });
     })
 }
 

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -40,17 +40,17 @@
 //! One `StatTrigger` attribute should be added to the log for each statistic it should update.
 //!
 //!   - `StatName` (mandatory) - The name of the statistic to change, as defined on the
-//!           corresponding [`StatDefinition`](../slog_extlog/stats/struct.StatDefinition.html).
+//!     corresponding [`StatDefinition`](../slog_extlog/stats/struct.StatDefinition.html).
 //!   - `Action` (mandatory) - one of: `Incr`, `Decr`, and `SetVal`, depending on whether this
-//!        change triggers an increment, decrement, or set to an explicit value.
+//!     change triggers an increment, decrement, or set to an explicit value.
 //!   - `Condition` (optional) - A condition, based on the log fields, for this stat to be changed.
-//!      if not set, the stat is changed on every log.  The value of this parameter is an
-//!        expression that returns a Boolean, and can use `self` for the current log object.
+//!     if not set, the stat is changed on every log.  The value of this parameter is an
+//!     expression that returns a Boolean, and can use `self` for the current log object.
 //!   - `Value` or `ValueFrom` - The value to increment/decrement/set.  One and only one
-//!   of these must be provided.  `Value` for a fixed number, `ValueFrom` for an arbitrary
-//!   expression to find the value that may return self.
+//!     of these must be provided.  `Value` for a fixed number, `ValueFrom` for an arbitrary
+//!     expression to find the value that may return self.
 //!   - `FixedGroups (optional)` - A comma-separated list of fixed tags to add to this statistic
-//!   for this trigger - see below.
+//!     for this trigger - see below.
 //!
 //! ### Grouped (tagged) statistics)
 //! Some statistics may be grouped with *tags*.  Tags can be defined in two ways.
@@ -515,12 +515,12 @@ fn impl_ext_loggable(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     // (which isn't the `to_str` or `to_short_str` name unfortunately).
     let (level, text, id) = parse_log_details(log_details);
     let level = match level {
-        slog::Level::Critical => "Critical",
-        slog::Level::Error => "Error",
-        slog::Level::Warning => "Warning",
-        slog::Level::Info => "Info",
-        slog::Level::Debug => "Debug",
-        slog::Level::Trace => "Trace",
+        Level::Critical => "Critical",
+        Level::Error => "Error",
+        Level::Warning => "Warning",
+        Level::Info => "Info",
+        Level::Debug => "Debug",
+        Level::Trace => "Trace",
     };
     let level = syn::Ident::new(level, proc_macro2::Span::call_site());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!  * External logs can be defined using this crate, and then logged using
 //!    a [`StatisticsLogger`].  They can also be used as triggers for statistics generation.
 //!  * For internal, low-level logging, the usual slog macros (`info!`, `debug!`, `trace!` etc)
-//! can be used.
+//!    can be used.
 //!
 //! Any object can be made into an external log by implementing [`ExtLoggable`].  In nearly all
 //! cases this trait should be automatically derived using the
@@ -42,6 +42,7 @@
 //! You can then call the [`slog_extlog::xlog!()`] macro, passing in the [`StatisticsLogger`] and
 //! an instance of your structure, and it will be logged according to the Logger's associated Drain
 //! as usual.
+//!
 //! Structure parameters will be added as key-value pairs, but with the bonus that you get
 //! type checking.
 //!
@@ -68,7 +69,7 @@
 //!
 //!   - Create a static set of statistic definitions using the [`define_stats`] macro.
 //!   - Add `StatTrigger` attributes to each external log that explains which statistics
-//!   the log should update.
+//!     the log should update.
 //!
 //! The automatic derivation code then takes care of updating the statistics as and when required.
 //!

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -87,18 +87,18 @@ pub trait StatDefinition: fmt::Debug {
 ///
 ///   - `StatName` is the externally-facing metric name.
 ///   - `Type` is the `StatType` of this statistic, for example `Counter`.
-///    Must be a valid subtype of that enum.
+///     Must be a valid subtype of that enum.
 ///   - `Description`  is a human readable description of the statistic.  This will be logged as
-///   the log message,
+///     the log message,
 ///   - The list of `tags` define field names to group the statistic by.
-///    A non-empty list indicates that this statistic should be split into groups,
-///   counting the stat separately for each different value of these fields that is seen.
-///   These might be a remote hostname, say, or a tag field.
+///     A non-empty list indicates that this statistic should be split into groups,
+///     counting the stat separately for each different value of these fields that is seen.
+///     These might be a remote hostname, say, or a tag field.
 ///     - If multiple tags are provided, the stat is counted separately for all distinct
 ///       combinations of tag values.
 ///     - Use of this feature should be avoided for fields that can take very many values, such as
-///   a subscriber number, or for large numbers of tags - each tag name and seen value adds a
-///   performance dip and a small memory overhead that is never freed.
+///       a subscriber number, or for large numbers of tags - each tag name and seen value adds a
+///       performance dip and a small memory overhead that is never freed.
 ///   - If the `Type` field is set to `BucketCounter`, then a `BucketMethod`, bucket label and bucket limits must
 ///     also be provided like so:
 ///

--- a/tests/stats_extlog.rs
+++ b/tests/stats_extlog.rs
@@ -1,6 +1,6 @@
-#![cfg(feature = "interval_logging")]
 //! Extlog tests for Stats tracker.
 //!
+#![cfg(feature = "interval_logging")]
 
 use slog::{info, o};
 use slog_extlog::{define_stats, xlog};
@@ -180,8 +180,8 @@ fn log_external_grouped(logger: &StatisticsLogger, name: String, error: u8) {
 fn get_stat_logs(stat_name: &str, data: &mut Buffer) -> Vec<serde_json::Value> {
     logs_in_range("STATS-1", "STATS-2", data)
         .iter()
-        .cloned()
         .filter(|l| l["name"] == stat_name)
+        .cloned()
         .collect()
 }
 

--- a/tests/stats_query.rs
+++ b/tests/stats_query.rs
@@ -92,22 +92,6 @@ struct BucketCounterLog {
 
 #[derive(ExtLoggable, Clone, Serialize)]
 #[LogDetails(
-    Id = "5",
-    Text = "cumulative test bucket counter stat log",
-    Level = "Info"
-)]
-#[StatTrigger(
-    StatName = "test_bucket_counter_cumul_freq",
-    Action = "Incr",
-    Value = "2"
-)]
-struct CumulBucketCounterLog {
-    #[BucketBy(StatName = "test_bucket_counter_cumul_freq")]
-    bucket_value: f32,
-}
-
-#[derive(ExtLoggable, Clone, Serialize)]
-#[LogDetails(
     Id = "6",
     Text = "test grouped bucket counter stat log",
     Level = "Info"


### PR DESCRIPTION
The main branch is failing to build since CI is using an up-to-date clippy with extra warnings/lints enabled.  This PR just brings the code up to that modern standard.

One point of interest is that clippy now has a `duplicated_attributes` lint that fires if someone uses two `StatTrigger` attributes on one structure (even if those attributes modify different stats).  This PR simply disables that lint for now, but this will affect downstream users too, so we should either come up with a way to teach clippy that these attributes are legitimate to repeat, or add guidance for users to work around the lint.