### PR TITLE
Remove non-determinism from extlog-derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- Stop using `HashMap`/`HashSet` in `slog-extlog-derive`.
+  - This removes a source of rustc HIR non-determinism for consumeing crates, resolving rustc failures when built with non-cargo build systems like bazel/buck. 
 
 ## [8.1.0]
 

--- a/benches/stats.rs
+++ b/benches/stats.rs
@@ -114,7 +114,7 @@ fn single_grouped_counter_multi_bucket(bench: &mut Bencher) {
         xlog!(
             logger,
             ThirdExternalLog {
-                name: format!("name-{}", idx),
+                name: format!("name-{idx}"),
             }
         );
         idx += 1;

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -179,7 +179,7 @@ impl FromStr for StatTriggerAction {
             "Decr" => Ok(StatTriggerAction::Decrement),
             "SetVal" => Ok(StatTriggerAction::SetValue),
             "None" => Ok(StatTriggerAction::Ignore),
-            s => Err(format!("Unknown StatTrigger action {}", s)),
+            s => Err(format!("Unknown StatTrigger action {s}")),
         }
     }
 }

--- a/slog-extlog-derive/src/lib.rs
+++ b/slog-extlog-derive/src/lib.rs
@@ -159,7 +159,7 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 use slog::Level;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -189,8 +189,8 @@ impl FromStr for StatTriggerAction {
 // a bucketing value.
 #[derive(Default)]
 struct FieldReferences {
-    stat_group_refs: HashMap<String, HashSet<syn::Ident>>,
-    bucket_by_ref: HashMap<String, syn::Ident>,
+    stat_group_refs: BTreeMap<String, BTreeSet<syn::Ident>>,
+    bucket_by_ref: BTreeMap<String, syn::Ident>,
 }
 
 // Info about a statistic trigger
@@ -200,8 +200,8 @@ struct StatTriggerData {
     condition_body: syn::Expr,
     action: StatTriggerAction,
     val: syn::Expr,
-    fixed_groups: HashMap<String, String>,
-    field_groups: HashSet<syn::Ident>,
+    fixed_groups: BTreeMap<String, String>,
+    field_groups: BTreeSet<syn::Ident>,
     bucket_by: Option<syn::Ident>,
 }
 
@@ -702,10 +702,10 @@ fn collate_field_references(fields: &syn::FieldsNamed) -> FieldReferences {
                         .insert(field_name);
                 }
                 RefType::BucketBy => match field_refs.bucket_by_ref.entry(stat_name.clone()) {
-                    std::collections::hash_map::Entry::Occupied(_) => {
+                    std::collections::btree_map::Entry::Occupied(_) => {
                         panic!("Multiple `BucketBy` attributes found for `{}`", stat_name)
                     }
-                    std::collections::hash_map::Entry::Vacant(v) => {
+                    std::collections::btree_map::Entry::Vacant(v) => {
                         v.insert(field_name);
                     }
                 },
@@ -751,7 +751,7 @@ fn parse_stat_trigger(attr: &syn::Attribute, field_refs: &FieldReferences) -> St
     let mut cond = None;
     let mut trigger_action = None;
     let mut trigger_value = None;
-    let mut fixed_groups = HashMap::new();
+    let mut fixed_groups = BTreeMap::new();
     attr.parse_nested_meta(|meta| {
         if meta.path.is_ident("StatName") {
             let value = meta.value().unwrap();

--- a/src/slog_test.rs
+++ b/src/slog_test.rs
@@ -105,12 +105,12 @@ pub fn assert_json_matches(actual: &serde_json::Value, expected: &serde_json::Va
     ) {
         if left.is_object() && right.is_object() {
             for (key, value) in right.as_object().unwrap().iter() {
-                let path = format!("{}.{}", path, key);
+                let path = format!("{path}.{key}");
                 check(actual, expected, &left[key], value, &path);
             }
         } else if left.is_array() && right.is_array() {
             for (index, value) in right.as_array().unwrap().iter().enumerate() {
-                let path = format!("{}.{}", path, index);
+                let path = format!("{path}.{index}");
                 check(actual, expected, &left[index], value, &path);
             }
         } else {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -266,7 +266,7 @@ impl slog::Value for BucketLimit {
 impl fmt::Display for BucketLimit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BucketLimit::Num(val) => write!(f, "{}", val),
+            BucketLimit::Num(val) => write!(f, "{val}"),
             BucketLimit::Unbounded => write!(f, "Unbounded"),
         }
     }
@@ -922,7 +922,7 @@ impl BucketCounterData {
                 .map(|(mut tag_values, index, val)| {
                     let bucket = self.buckets.get(index).expect("Invalid bucket index");
                     // Add the bucket label value as an additional tag value.
-                    tag_values.push_str(&format!(",{}", bucket));
+                    tag_values.push_str(&format!(",{bucket}"));
                     (tag_values, val)
                 })
                 .collect()


### PR DESCRIPTION
I was building a consumer of slog-extlog-derive with buck2 and I encountered rustc errors caused by non-determinism in the derive macro, caused by the use of HashMap/HashSe.

This PR replaces those usages with BTreeMap/BTreeSet to resolve this.
